### PR TITLE
docs(swagger): clarify endpoint encryption behavior

### DIFF
--- a/src/swagger/paths.json
+++ b/src/swagger/paths.json
@@ -62,7 +62,7 @@
         "/credentials": {
             "post": {
                 "summary": "Store private data with automatic encryption.",
-                "description": "Store private data with automatic encryption. The service encrypts your data before storage — you don't need to encrypt it yourself. The response includes a URI (the location of your stored data), a hash (a fingerprint to verify the data hasn't changed), and a key (your unique decryption key). Important: Save the key securely. Without it, your data cannot be decrypted — not even by us. Use this endpoint for sensitive information like verifiable credentials or protected documents.",
+                "description": "Store private data with automatic encryption. The service encrypts your data before storage — you don't need to encrypt it yourself. The response includes a URI (the location of your stored data), a hash (a fingerprint to verify the data hasn't changed), and a key (your unique decryption key).\n\n**Important**: Save the key securely. Without it, your data cannot be decrypted — **not even by us**. Use this endpoint for sensitive information like verifiable credentials or protected documents.",
                 "requestBody": {
                     "content": {
                         "application/json": {


### PR DESCRIPTION
## Summary

Updates OpenAPI/Swagger descriptions to clearly explain the difference between the two storage endpoints:
- **`/documents`**: stores public data as-is without encryption
- **`/credentials`**: automatically encrypts private data before storage

## Changes

- Updated endpoint summaries to distinguish public vs private data storage
- Added detailed descriptions explaining what each endpoint does
- Added field-level descriptions for response properties (uri, hash, key)
- Emphasized key management for the credentials endpoint