### PR TITLE
fix(ci): checkout main branch on workflow_run trigger

### DIFF
--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -1,11 +1,8 @@
 name: package
 
 on:
-    push:
-        tags:
-            - '*.*.*'
     workflow_dispatch:
-        # Run the workflow when the Release workflow completes
+    # Run the workflow when the Release workflow completes
     workflow_run:
         workflows: ['Release']
         types:
@@ -14,16 +11,19 @@ on:
 jobs:
     build:
         runs-on: ubuntu-latest
-        # Trigger the job only if the Release Tagging job was successful or manually triggered
-        if: ${{ startsWith(github.ref, 'refs/tags/') || github.event.workflow_run.conclusion == 'success' || github.event.ref == 'refs/heads/main' }}
+        # Run if Release workflow succeeded or manually triggered
+        if: ${{ github.event.workflow_run.conclusion == 'success' || github.event_name == 'workflow_dispatch' }}
 
         env:
-            # Only push the image if the new tag is pushed or manually triggered
-            PUSH_CONDITION: ${{ startsWith(github.ref, 'refs/tags/') || github.event.workflow_run.conclusion == 'success' || github.ref == 'refs/heads/main' }}
+            # Always push when conditions above are met
+            PUSH_CONDITION: true
 
         steps:
             - name: Checkout
               uses: actions/checkout@v4
+              with:
+                  # On workflow_run, checkout the exact commit that triggered Release
+                  ref: ${{ github.event_name == 'workflow_run' && github.event.workflow_run.head_sha || github.ref }}
 
             # Get version from version.json for workflow_run triggers
             - name: Get version from version.json
@@ -37,12 +37,10 @@ jobs:
               uses: docker/metadata-action@v5
               with:
                   images: ghcr.io/${{github.repository}}
-                  flavor: |
-                      latest=auto
                   tags: |
-                      type=semver,pattern={{version}}
+                      type=raw,value=${{ steps.get_version.outputs.version }}
+                      type=raw,value=latest
                       type=sha
-                      type=raw,value=${{ steps.get_version.outputs.version }},enable=${{ github.event_name == 'workflow_run' }}
 
             # Set up QEMU for multi-platform builds
             - name: Set up QEMU

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -74,8 +74,22 @@ jobs:
                   fi
                   echo "new_version=$new_version" >> "$GITHUB_OUTPUT"
 
+            # Check if the tag already exists
+            - name: Check if tag exists
+              id: check_tag
+              run: |
+                  new_version=${{ steps.retrieve_version.outputs.new_version }}
+                  if git ls-remote --tags origin | grep -q "refs/tags/$new_version$"; then
+                    echo "Tag $new_version already exists, skipping release"
+                    echo "tag_exists=true" >> "$GITHUB_OUTPUT"
+                  else
+                    echo "Tag $new_version does not exist, proceeding with release"
+                    echo "tag_exists=false" >> "$GITHUB_OUTPUT"
+                  fi
+
             # Create tag to the repository by using the version from the output file
             - name: Create tag
+              if: steps.check_tag.outputs.tag_exists == 'false'
               id: create-tag
               run: |
                   new_version=${{ steps.retrieve_version.outputs.new_version }}
@@ -89,11 +103,12 @@ jobs:
 
             # Create GitHub release
             - name: Create GitHub Release
+              if: steps.check_tag.outputs.tag_exists == 'false'
               env:
                   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
               run: |
                   new_version=${{ steps.retrieve_version.outputs.new_version }}
-                  new_tag=${{ steps.create-tag.outputs.new_tag }}          
+                  new_tag=${{ steps.create-tag.outputs.new_tag }}
 
                   sed -n "/## \[$new_version\]/,/## \[/p" CHANGELOG.md | sed '$d' > release_notes.md
 


### PR DESCRIPTION
## Summary

Fix release and package workflow reliability issues.

### Release workflow (`release.yml`)
- Add tag existence check before creating
- Skip release if version already tagged (prevents failures on repeated pushes to main)

### Package workflow (`package.yml`)
- Remove tag push trigger (doesn't work with GITHUB_TOKEN anyway)
- Use `workflow_run.head_sha` to checkout exact release commit
- Simplify Docker tags: `{version}`, `latest`, `sha-{sha}`

## Release Flow (after fix)

```
PR merged to main
       │
       ▼
Release workflow
       ├─► Check if tag exists
       │      ├─► Yes: Skip (no-op)
       │      └─► No: Create tag + GitHub release
       │
       ▼ (workflow_run)
Package workflow
       ├─► Checkout exact commit (head_sha)
       ├─► Read version.json
       └─► Build & push Docker image
              • :2.0.0
              • :latest
              • :sha-abc123
```

Closes #48