### PR TITLE
fix(swagger): use config values for Swagger UI server URL

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -18,7 +18,7 @@ app.use(
         // req.hostname, req.socket.localPort) which reflect the container's internal address.
         // Omit default ports (443 for HTTPS, 80 for HTTP) to produce standard URLs.
         const isDefaultPort =
-            (PROTOCOL === 'https' && String(PORT) === '443') || (PROTOCOL === 'http' && String(PORT) === '80');
+            (PROTOCOL === 'https' && Number(PORT) === 443) || (PROTOCOL === 'http' && Number(PORT) === 80);
         const portSuffix = isDefaultPort ? '' : `:${PORT}`;
         const url = `${PROTOCOL}://${DOMAIN}${portSuffix}/api/${API_VERSION}`;
         swaggerJson = updateSwagger(swaggerJson, { version: API_VERSION, url });


### PR DESCRIPTION
This PR fixes the Swagger UI server URL so it produces correct external-facing URLs when the app runs behind a reverse proxy, eliminating mixed-content browser errors.

Previously, the URL was built from request internals (`req.protocol`, `req.hostname`, `req.socket.localPort`) which always reflect the container's internal address (e.g. `http://host:3333`). Now it uses the existing `PROTOCOL`, `DOMAIN`, and `PORT` config variables, with default ports (443 for HTTPS, 80 for HTTP) omitted.

## Changes

- **src/app.ts**: Replace request internals with `PROTOCOL`, `DOMAIN`, `PORT` config values for Swagger server URL. Default ports are omitted to produce standard URLs.
- **e2e/swagger-url.e2e.test.ts**: 6 E2E tests covering default port omission (HTTPS/443, HTTP/80), non-standard port inclusion (HTTP/3333, HTTPS/8443, HTTP/8080), and string port handling from environment variables.

## Test plan

- [x] HTTPS with port 443 → `https://api.example.com/api/1.0.0` (port omitted)
- [x] HTTP with port 80 → `http://example.com/api/1.0.0` (port omitted)
- [x] HTTP with port 3333 → `http://localhost:3333/api/1.0.0` (port included)
- [x] HTTPS with port 8443 → `https://api.example.com:8443/api/1.0.0` (port included)
- [x] HTTP with port 8080 → `http://dev.example.com:8080/api/1.0.0` (port included)
- [x] String port "443" from env vars handled correctly
- [x] All 70 tests pass (56 unit + 8 auth e2e + 6 swagger URL e2e)
- [x] Build, TypeScript type-check, and lint all clean