### PR TITLE
fix: dotenv loading order and objectExists key handling

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -1,3 +1,8 @@
+// dotenv must be loaded before any other imports so that process.env values
+// are available when the remaining modules evaluate their top-level constants.
+import dotenv from 'dotenv';
+dotenv.config();
+
 import fs from 'fs';
 import { dirname } from 'path';
 import { fileURLToPath } from 'url';

--- a/src/routes/credentials/service.ts
+++ b/src/routes/credentials/service.ts
@@ -42,13 +42,13 @@ export class CredentialsService {
                 throw new BadRequestError('Data must be a JSON object. Please provide a valid JSON object.');
             }
 
-            const credentialId = id ?? v4();
+            const credentialId = id || v4();
 
             if (!isValidUUID(credentialId)) {
                 throw new BadRequestError(`Invalid id ${credentialId}. Please provide a valid UUID.`);
             }
 
-            const objectExists = await storageService.objectExists(bucket, credentialId);
+            const objectExists = await storageService.objectExists(bucket, credentialId + '.json');
 
             if (objectExists) {
                 throw new ConflictError('A document with the provided ID already exists in the specified bucket.');

--- a/src/routes/documents/service.ts
+++ b/src/routes/documents/service.ts
@@ -41,13 +41,13 @@ export class DocumentsService {
                 throw new BadRequestError('Data must be a JSON object. Please provide a valid JSON object.');
             }
 
-            const credentialId = id ?? v4();
+            const credentialId = id || v4();
 
             if (!isValidUUID(credentialId)) {
                 throw new BadRequestError(`Invalid id ${credentialId}. Please provide a valid UUID.`);
             }
 
-            const objectExists = await storageService.objectExists(bucket, credentialId);
+            const objectExists = await storageService.objectExists(bucket, credentialId + '.json');
 
             if (objectExists) {
                 throw new ConflictError('A document with the provided ID already exists in the specified bucket.');

--- a/src/server.ts
+++ b/src/server.ts
@@ -1,6 +1,3 @@
-import dotenv from 'dotenv';
-dotenv.config();
-
 import { app } from './app';
 import { API_VERSION, DOMAIN, EXTERNAL_PORT, PORT, PROTOCOL, getApiKey } from './config';
 import { buildBaseUrl } from './utils';

--- a/src/services/storage/gcp.ts
+++ b/src/services/storage/gcp.ts
@@ -19,7 +19,7 @@ export class GCPStorageService implements IStorageService {
      * @param contentType The content type of the file.
      * @returns A promise that resolves to the public URL of the uploaded file.
      */
-    async uploadFile(bucket: string, key: string, body: string, contentType: string) {
+    async uploadFile(bucket: string, key: string, body: string | Buffer, contentType: string) {
         const bucketInstance = this.storage.bucket(bucket);
         const file = bucketInstance.file(key);
 
@@ -42,7 +42,7 @@ export class GCPStorageService implements IStorageService {
      */
     async objectExists(bucket: string, key: string): Promise<boolean> {
         const bucketInstance = this.storage.bucket(bucket);
-        const file = bucketInstance.file(`${key}.json`);
+        const file = bucketInstance.file(key);
 
         try {
             const [exists] = await file.exists();

--- a/src/services/storage/local.ts
+++ b/src/services/storage/local.ts
@@ -19,14 +19,14 @@ export class LocalStorageService implements IStorageService {
      * @param contentType The content type of the file.
      * @returns A promise that resolves to the public URL of the uploaded file.
      */
-    async uploadFile(bucket: string, key: string, body: string, contentType: string) {
+    async uploadFile(bucket: string, key: string, body: string | Buffer, contentType: string) {
         const filePath = path.join(__dirname, LOCAL_DIRECTORY, bucket, key);
 
         const directory = path.dirname(filePath);
         // Create directories if they don't exist
         fs.mkdirSync(directory, { recursive: true });
 
-        // Write JSON data to file
+        // Write data to file
         fs.writeFileSync(filePath, body);
         return { uri: buildBaseUrl(PROTOCOL, DOMAIN, EXTERNAL_PORT, `api/${API_VERSION}/${bucket}/${key}`) };
     }
@@ -38,7 +38,7 @@ export class LocalStorageService implements IStorageService {
      * @returns A promise that resolves to a boolean indicating whether the object exists.
      */
     async objectExists(bucket: string, key: string): Promise<boolean> {
-        const filePath = path.join(__dirname, LOCAL_DIRECTORY, bucket, key + '.json');
+        const filePath = path.join(__dirname, LOCAL_DIRECTORY, bucket, key);
         return new Promise<boolean>((resolve) => {
             fs.access(filePath, fs.constants.F_OK, (err) => {
                 resolve(!err);


### PR DESCRIPTION
This PR fixes two independent bugs and prepares the storage layer for binary file support.

**dotenv loading order**: Moves `dotenv.config()` from `server.ts` to the top of `config.ts` so environment variables are available when config constants are evaluated at import time. Previously, importing `config.ts` from other entry points (e.g. tests) would see undefined env vars.

**objectExists key handling**: The `.json` extension was being appended inside the GCP and local storage `objectExists` methods, which meant callers had no control over the key format. This broke for non-JSON files. The extension is now appended by the caller (credentials/documents services) where the file format is known, and storage methods use the key verbatim.

## Changes

- `src/config.ts` — import and call dotenv at the top
- `src/server.ts` — remove duplicate dotenv import
- `src/services/storage/gcp.ts` — remove `.json` suffix from `objectExists`, widen `uploadFile` to accept `Buffer`
- `src/services/storage/local.ts` — same changes as GCP
- `src/routes/credentials/service.ts` — append `.json` to `objectExists` call, use `||` instead of `??` for ID fallback
- `src/routes/documents/service.ts` — same changes as credentials

## Test plan
- [x] dotenv values loaded correctly in config when imported directly
- [x] objectExists checks the correct key with `.json` suffix
- [x] Existing document and credential upload flows unaffected
- [x] All unit and E2E tests pass