### PR TITLE
test(e2e): replace mocked E2E tests with real S3-compatible storage

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,12 @@
+node_modules
+dist
+coverage
+.git
+.github
+.claude
+documentation
+e2e
+*.md
+.env
+.env.*
+report.json

--- a/.github/workflows/test_build.yml
+++ b/.github/workflows/test_build.yml
@@ -40,8 +40,6 @@ jobs:
 
             - name: Run e2e tests
               run: yarn test:e2e:ci
-              env:
-                  API_KEY: test-api-key-ci
 
     build_docs:
         runs-on: ubuntu-latest

--- a/docker-compose.e2e.yml
+++ b/docker-compose.e2e.yml
@@ -1,0 +1,56 @@
+services:
+  minio:
+    image: minio/minio
+    ports:
+      - "9010:9000"
+      - "9011:9001"
+    environment:
+      MINIO_ROOT_USER: minioadmin
+      MINIO_ROOT_PASSWORD: minioadmin
+    command: server /data --console-address ":9001"
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:9000/minio/health/live"]
+      interval: 5s
+      timeout: 5s
+      retries: 5
+
+  minio-init:
+    image: minio/mc
+    depends_on:
+      minio:
+        condition: service_healthy
+    entrypoint: >
+      /bin/sh -c "
+      mc alias set local http://minio:9000 minioadmin minioadmin;
+      mc mb local/verifiable-credentials;
+      mc mb local/files;
+      mc anonymous set download local/verifiable-credentials;
+      mc anonymous set download local/files;
+      exit 0;
+      "
+
+  app:
+    build:
+      context: .
+      dockerfile: Dockerfile
+    ports:
+      - "3334:3333"
+    environment:
+      STORAGE_TYPE: aws
+      S3_ENDPOINT: http://minio:9000
+      S3_FORCE_PATH_STYLE: "true"
+      S3_REGION: us-east-1
+      API_KEY: test-api-key-e2e
+      AWS_ACCESS_KEY_ID: minioadmin
+      AWS_SECRET_ACCESS_KEY: minioadmin
+      AVAILABLE_BUCKETS: verifiable-credentials,files
+      PORT: 3333
+    depends_on:
+      minio-init:
+        condition: service_completed_successfully
+    healthcheck:
+      test: ["CMD", "wget", "--spider", "-q", "http://localhost:3333/health-check"]
+      interval: 5s
+      timeout: 5s
+      retries: 10
+      start_period: 15s

--- a/e2e/helpers.ts
+++ b/e2e/helpers.ts
@@ -1,0 +1,63 @@
+import crypto from 'crypto';
+
+const { apiVersion: API_VERSION } = require('../version.json');
+
+/** Base URL for the containerised app */
+export const APP_BASE_URL = 'http://localhost:3334';
+
+/** MinIO internal endpoint as configured in the app container */
+const MINIO_INTERNAL_ENDPOINT = 'http://minio:9000';
+
+/** MinIO endpoint as accessible from the test runner host */
+const MINIO_HOST_ENDPOINT = 'http://localhost:9010';
+
+/** API key matching the hardcoded value in docker-compose.e2e.yml */
+export const API_KEY = 'test-api-key-e2e';
+
+/** API version from version.json, used for URL paths */
+export { API_VERSION };
+
+/**
+ * Rewrites a URI returned by the API to be resolvable from the host machine.
+ *
+ * The app container generates URIs using its internal Docker network endpoint
+ * (http://minio:9000). The test runner on the host cannot resolve 'minio',
+ * so this function replaces the internal endpoint with the host-mapped port.
+ */
+export function resolveUri(uri: string): string {
+    return uri.replace(MINIO_INTERNAL_ENDPOINT, MINIO_HOST_ENDPOINT);
+}
+
+/**
+ * Computes a SHA-256 hash of the input, matching the format used by CryptographyService.
+ */
+export function computeHash(input: string | Buffer): string {
+    return crypto.createHash('sha256').update(input).digest('hex');
+}
+
+/** Represents the encrypted envelope structure stored by the private API. */
+export interface EncryptedEnvelope {
+    cipherText: string;
+    iv: string;
+    tag: string;
+    type: string;
+    contentType: string;
+}
+
+/**
+ * Decrypts an encrypted envelope using AES-256-GCM.
+ *
+ * This reverses the encryption performed by CryptographyService.encryptString().
+ * The decryption key is returned by the private API endpoint.
+ */
+export function decryptEnvelope(envelope: EncryptedEnvelope, decryptionKey: string): string {
+    const decipher = crypto.createDecipheriv(
+        'aes-256-gcm',
+        Buffer.from(decryptionKey, 'hex'),
+        Buffer.from(envelope.iv, 'base64'),
+    );
+    decipher.setAuthTag(Buffer.from(envelope.tag, 'base64'));
+    let decrypted = decipher.update(envelope.cipherText, 'base64', 'utf8');
+    decrypted += decipher.final('utf8');
+    return decrypted;
+}

--- a/e2e/private.s3.e2e.test.ts
+++ b/e2e/private.s3.e2e.test.ts
@@ -1,0 +1,453 @@
+import request from 'supertest';
+
+import { APP_BASE_URL, API_KEY, API_VERSION, resolveUri, computeHash, decryptEnvelope, EncryptedEnvelope } from './helpers';
+
+jest.setTimeout(30000);
+
+const { v4: uuidv4 } = require('uuid');
+
+const testDocument = {
+    '@context': ['https://www.w3.org/2018/credentials/v1'],
+    type: ['VerifiableCredential'],
+    issuer: 'did:example:123',
+    credentialSubject: {
+        id: 'did:example:456',
+        name: 'Test Subject',
+    },
+};
+
+// Minimal valid PNG (1x1 transparent pixel)
+const MINIMAL_PNG = Buffer.from(
+    '89504e470d0a1a0a0000000d49484452000000010000000108060000001f15c489' +
+    '0000000a49444154789c626000000002000198e195280000000049454e44ae426082',
+    'hex',
+);
+
+// Minimal valid PDF
+const MINIMAL_PDF = Buffer.from(
+    '%PDF-1.0\n1 0 obj<</Type/Catalog/Pages 2 0 R>>endobj\n' +
+    '2 0 obj<</Type/Pages/Kids[3 0 R]/Count 1>>endobj\n' +
+    '3 0 obj<</Type/Page/MediaBox[0 0 3 3]/Parent 2 0 R>>endobj\n' +
+    'xref\n0 4\ntrailer<</Size 4/Root 1 0 R>>\nstartxref\n190\n%%EOF',
+);
+
+// Buffer exceeding 10MB MAX_UPLOAD_SIZE
+const OVERSIZED_FILE = Buffer.alloc(10485761, 0x00);
+
+describe('Private API - S3 E2E Tests', () => {
+    describe(`POST /api/${API_VERSION}/private (JSON)`, () => {
+        describe('Authentication', () => {
+            it('should return 401 when API key is missing', async () => {
+                const response = await request(APP_BASE_URL)
+                    .post(`/api/${API_VERSION}/private`)
+                    .send({ bucket: 'verifiable-credentials', data: testDocument })
+                    .expect(401);
+
+                expect(response.body).toHaveProperty('message');
+            });
+
+            it('should return 401 when API key is invalid', async () => {
+                const response = await request(APP_BASE_URL)
+                    .post(`/api/${API_VERSION}/private`)
+                    .set('X-API-Key', 'invalid-key')
+                    .send({ bucket: 'verifiable-credentials', data: testDocument })
+                    .expect(401);
+
+                expect(response.body).toHaveProperty('message');
+            });
+        });
+
+        describe('Validation', () => {
+            it('should return 400 when bucket is missing', async () => {
+                const response = await request(APP_BASE_URL)
+                    .post(`/api/${API_VERSION}/private`)
+                    .set('X-API-Key', API_KEY)
+                    .send({ data: testDocument })
+                    .expect(400);
+
+                expect(response.body.message).toContain('Bucket is required');
+            });
+
+            it('should return 400 when bucket is not in available list', async () => {
+                const response = await request(APP_BASE_URL)
+                    .post(`/api/${API_VERSION}/private`)
+                    .set('X-API-Key', API_KEY)
+                    .send({ bucket: 'nonexistent-bucket', data: testDocument })
+                    .expect(400);
+
+                expect(response.body.message).toContain('Invalid bucket');
+            });
+
+            it('should return 400 when data is not a JSON object', async () => {
+                const response = await request(APP_BASE_URL)
+                    .post(`/api/${API_VERSION}/private`)
+                    .set('X-API-Key', API_KEY)
+                    .send({ bucket: 'verifiable-credentials', data: 'not-an-object' })
+                    .expect(400);
+
+                expect(response.body.message).toContain('Data must be a JSON object');
+            });
+
+            it('should return 400 when id is not a valid UUID', async () => {
+                const response = await request(APP_BASE_URL)
+                    .post(`/api/${API_VERSION}/private`)
+                    .set('X-API-Key', API_KEY)
+                    .send({ bucket: 'verifiable-credentials', id: 'not-a-uuid', data: testDocument })
+                    .expect(400);
+
+                expect(response.body.message).toContain('Invalid id');
+            });
+        });
+
+        describe('Storage', () => {
+            it('should return 201 with uri, hash, and decryptionKey', async () => {
+                const response = await request(APP_BASE_URL)
+                    .post(`/api/${API_VERSION}/private`)
+                    .set('X-API-Key', API_KEY)
+                    .send({ bucket: 'verifiable-credentials', data: testDocument })
+                    .expect(201);
+
+                expect(response.body.uri).toEqual(expect.any(String));
+                expect(response.body.uri.length).toBeGreaterThan(0);
+                expect(response.body.hash).toEqual(expect.any(String));
+                expect(response.body.hash.length).toBeGreaterThan(0);
+                expect(response.body.decryptionKey).toEqual(expect.any(String));
+                expect(response.body.decryptionKey.length).toBeGreaterThan(0);
+            });
+
+            it('should return 201 with custom UUID id', async () => {
+                const customId = uuidv4();
+                const response = await request(APP_BASE_URL)
+                    .post(`/api/${API_VERSION}/private`)
+                    .set('X-API-Key', API_KEY)
+                    .send({ bucket: 'verifiable-credentials', id: customId, data: testDocument })
+                    .expect(201);
+
+                expect(response.body.uri).toEqual(expect.any(String));
+                expect(response.body.uri.length).toBeGreaterThan(0);
+                expect(response.body.uri).toContain(customId);
+            });
+
+            it('should return 409 when document with same id already exists', async () => {
+                const duplicateId = uuidv4();
+
+                await request(APP_BASE_URL)
+                    .post(`/api/${API_VERSION}/private`)
+                    .set('X-API-Key', API_KEY)
+                    .send({ bucket: 'verifiable-credentials', id: duplicateId, data: testDocument })
+                    .expect(201);
+
+                const response = await request(APP_BASE_URL)
+                    .post(`/api/${API_VERSION}/private`)
+                    .set('X-API-Key', API_KEY)
+                    .send({ bucket: 'verifiable-credentials', id: duplicateId, data: testDocument })
+                    .expect(409);
+
+                expect(response.body.message).toContain('already exists');
+            });
+        });
+
+        describe('Round-trip verification', () => {
+            it('should store an encrypted envelope retrievable via GET on returned URI', async () => {
+                const postResponse = await request(APP_BASE_URL)
+                    .post(`/api/${API_VERSION}/private`)
+                    .set('X-API-Key', API_KEY)
+                    .send({ bucket: 'verifiable-credentials', data: testDocument })
+                    .expect(201);
+
+                const resolvedUri = resolveUri(postResponse.body.uri);
+                const getResponse = await fetch(resolvedUri);
+                const envelope = await getResponse.json();
+
+                expect(typeof envelope).toBe('object');
+                expect(envelope).not.toBeNull();
+            });
+
+            it('should return a valid encrypted envelope with cipherText, iv, tag, type, contentType', async () => {
+                const postResponse = await request(APP_BASE_URL)
+                    .post(`/api/${API_VERSION}/private`)
+                    .set('X-API-Key', API_KEY)
+                    .send({ bucket: 'verifiable-credentials', data: testDocument })
+                    .expect(201);
+
+                const resolvedUri = resolveUri(postResponse.body.uri);
+                const getResponse = await fetch(resolvedUri);
+                const envelope: EncryptedEnvelope = await getResponse.json();
+
+                expect(envelope).toHaveProperty('cipherText');
+                expect(envelope).toHaveProperty('iv');
+                expect(envelope).toHaveProperty('tag');
+                expect(envelope).toHaveProperty('type');
+                expect(envelope).toHaveProperty('contentType');
+                expect(envelope.type).toBe('aes-256-gcm');
+                expect(envelope.contentType).toBe('application/json');
+            });
+        });
+
+        describe('Decrypt verification', () => {
+            it('should decrypt the envelope with the returned key to recover the original JSON', async () => {
+                const postResponse = await request(APP_BASE_URL)
+                    .post(`/api/${API_VERSION}/private`)
+                    .set('X-API-Key', API_KEY)
+                    .send({ bucket: 'verifiable-credentials', data: testDocument })
+                    .expect(201);
+
+                const { uri, decryptionKey } = postResponse.body;
+                const resolvedUri = resolveUri(uri);
+                const getResponse = await fetch(resolvedUri);
+                const envelope: EncryptedEnvelope = await getResponse.json();
+
+                const decrypted = decryptEnvelope(envelope, decryptionKey);
+                const recovered = JSON.parse(decrypted);
+
+                expect(recovered).toEqual(testDocument);
+            });
+
+            it('should produce a valid SHA-256 hash of the original (unencrypted) data', async () => {
+                const postResponse = await request(APP_BASE_URL)
+                    .post(`/api/${API_VERSION}/private`)
+                    .set('X-API-Key', API_KEY)
+                    .send({ bucket: 'verifiable-credentials', data: testDocument })
+                    .expect(201);
+
+                const expectedHash = computeHash(JSON.stringify(testDocument));
+                expect(postResponse.body.hash).toBe(expectedHash);
+            });
+        });
+    });
+
+    describe(`POST /api/${API_VERSION}/private (Binary)`, () => {
+        describe('Authentication', () => {
+            it('should return 401 when API key is missing', async () => {
+                const response = await request(APP_BASE_URL)
+                    .post(`/api/${API_VERSION}/private`)
+                    .attach('file', MINIMAL_PNG, { filename: 'test.png', contentType: 'image/png' })
+                    .field('bucket', 'files')
+                    .expect(401);
+
+                expect(response.body).toHaveProperty('message');
+            });
+
+            it('should return 401 when API key is invalid', async () => {
+                const response = await request(APP_BASE_URL)
+                    .post(`/api/${API_VERSION}/private`)
+                    .set('X-API-Key', 'invalid-key')
+                    .attach('file', MINIMAL_PNG, { filename: 'test.png', contentType: 'image/png' })
+                    .field('bucket', 'files')
+                    .expect(401);
+
+                expect(response.body).toHaveProperty('message');
+            });
+        });
+
+        describe('Validation', () => {
+            it('should return 400 when no file is attached', async () => {
+                const response = await request(APP_BASE_URL)
+                    .post(`/api/${API_VERSION}/private`)
+                    .set('X-API-Key', API_KEY)
+                    .field('bucket', 'files')
+                    .expect(400);
+
+                expect(response.body.message).toContain('File is required for multipart uploads');
+            });
+
+            it('should return 400 when bucket is missing', async () => {
+                const response = await request(APP_BASE_URL)
+                    .post(`/api/${API_VERSION}/private`)
+                    .set('X-API-Key', API_KEY)
+                    .attach('file', MINIMAL_PNG, { filename: 'test.png', contentType: 'image/png' })
+                    .expect(400);
+
+                expect(response.body.message).toContain('Bucket is required');
+            });
+
+            it('should return 400 when bucket is not in available list', async () => {
+                const response = await request(APP_BASE_URL)
+                    .post(`/api/${API_VERSION}/private`)
+                    .set('X-API-Key', API_KEY)
+                    .attach('file', MINIMAL_PNG, { filename: 'test.png', contentType: 'image/png' })
+                    .field('bucket', 'nonexistent-bucket')
+                    .expect(400);
+
+                expect(response.body.message).toContain('Invalid bucket');
+            });
+
+            it('should return 400 when id is not a valid UUID', async () => {
+                const response = await request(APP_BASE_URL)
+                    .post(`/api/${API_VERSION}/private`)
+                    .set('X-API-Key', API_KEY)
+                    .attach('file', MINIMAL_PNG, { filename: 'test.png', contentType: 'image/png' })
+                    .field('bucket', 'files')
+                    .field('id', 'not-a-valid-uuid')
+                    .expect(400);
+
+                expect(response.body.message).toContain('Invalid id');
+            });
+
+            it('should reject when MIME type is not in allow-list', async () => {
+                const response = await request(APP_BASE_URL)
+                    .post(`/api/${API_VERSION}/private`)
+                    .set('X-API-Key', API_KEY)
+                    .attach('file', Buffer.from('not a real zip'), { filename: 'test.zip', contentType: 'application/zip' })
+                    .field('bucket', 'files');
+
+                expect(response.status).toBe(400);
+                expect(response.body.message).toContain('not allowed');
+            });
+
+            it('should return 413 when file exceeds maximum allowed size', async () => {
+                const response = await request(APP_BASE_URL)
+                    .post(`/api/${API_VERSION}/private`)
+                    .set('X-API-Key', API_KEY)
+                    .attach('file', OVERSIZED_FILE, { filename: 'large.png', contentType: 'image/png' })
+                    .field('bucket', 'files')
+                    .expect(413);
+
+                expect(response.body.message).toContain('exceeds the maximum allowed size');
+            });
+        });
+
+        describe('Storage', () => {
+            it('should return 201 when uploading a valid PNG and return decryptionKey', async () => {
+                const response = await request(APP_BASE_URL)
+                    .post(`/api/${API_VERSION}/private`)
+                    .set('X-API-Key', API_KEY)
+                    .attach('file', MINIMAL_PNG, { filename: 'test.png', contentType: 'image/png' })
+                    .field('bucket', 'files')
+                    .expect(201);
+
+                expect(response.body.uri).toEqual(expect.any(String));
+                expect(response.body.uri.length).toBeGreaterThan(0);
+                expect(response.body.hash).toEqual(expect.any(String));
+                expect(response.body.hash.length).toBeGreaterThan(0);
+                expect(response.body.decryptionKey).toEqual(expect.any(String));
+                expect(response.body.decryptionKey.length).toBeGreaterThan(0);
+            });
+
+            it('should return 201 when uploading a valid PDF and return decryptionKey', async () => {
+                const response = await request(APP_BASE_URL)
+                    .post(`/api/${API_VERSION}/private`)
+                    .set('X-API-Key', API_KEY)
+                    .attach('file', MINIMAL_PDF, { filename: 'test.pdf', contentType: 'application/pdf' })
+                    .field('bucket', 'files')
+                    .expect(201);
+
+                expect(response.body.uri).toEqual(expect.any(String));
+                expect(response.body.uri.length).toBeGreaterThan(0);
+                expect(response.body.hash).toEqual(expect.any(String));
+                expect(response.body.hash.length).toBeGreaterThan(0);
+                expect(response.body.decryptionKey).toEqual(expect.any(String));
+                expect(response.body.decryptionKey.length).toBeGreaterThan(0);
+            });
+
+            it('should return 201 with a custom UUID id', async () => {
+                const customId = uuidv4();
+                const response = await request(APP_BASE_URL)
+                    .post(`/api/${API_VERSION}/private`)
+                    .set('X-API-Key', API_KEY)
+                    .attach('file', MINIMAL_PNG, { filename: 'test.png', contentType: 'image/png' })
+                    .field('bucket', 'files')
+                    .field('id', customId)
+                    .expect(201);
+
+                expect(response.body.uri).toEqual(expect.any(String));
+                expect(response.body.uri.length).toBeGreaterThan(0);
+                expect(response.body.uri).toContain(customId);
+            });
+
+            it('should return 409 when file with same id already exists', async () => {
+                const duplicateId = uuidv4();
+
+                await request(APP_BASE_URL)
+                    .post(`/api/${API_VERSION}/private`)
+                    .set('X-API-Key', API_KEY)
+                    .attach('file', MINIMAL_PNG, { filename: 'test.png', contentType: 'image/png' })
+                    .field('bucket', 'files')
+                    .field('id', duplicateId)
+                    .expect(201);
+
+                const response = await request(APP_BASE_URL)
+                    .post(`/api/${API_VERSION}/private`)
+                    .set('X-API-Key', API_KEY)
+                    .attach('file', MINIMAL_PNG, { filename: 'test.png', contentType: 'image/png' })
+                    .field('bucket', 'files')
+                    .field('id', duplicateId)
+                    .expect(409);
+
+                expect(response.body.message).toContain('already exists');
+            });
+        });
+
+        describe('Round-trip verification', () => {
+            it('should store an encrypted envelope retrievable via GET on returned URI', async () => {
+                const postResponse = await request(APP_BASE_URL)
+                    .post(`/api/${API_VERSION}/private`)
+                    .set('X-API-Key', API_KEY)
+                    .attach('file', MINIMAL_PNG, { filename: 'test.png', contentType: 'image/png' })
+                    .field('bucket', 'files')
+                    .expect(201);
+
+                const resolvedUri = resolveUri(postResponse.body.uri);
+                const getResponse = await fetch(resolvedUri);
+                const envelope = await getResponse.json();
+
+                expect(typeof envelope).toBe('object');
+                expect(envelope).not.toBeNull();
+            });
+
+            it('should return a valid encrypted envelope with cipherText, iv, tag, type, contentType', async () => {
+                const postResponse = await request(APP_BASE_URL)
+                    .post(`/api/${API_VERSION}/private`)
+                    .set('X-API-Key', API_KEY)
+                    .attach('file', MINIMAL_PNG, { filename: 'test.png', contentType: 'image/png' })
+                    .field('bucket', 'files')
+                    .expect(201);
+
+                const resolvedUri = resolveUri(postResponse.body.uri);
+                const getResponse = await fetch(resolvedUri);
+                const envelope: EncryptedEnvelope = await getResponse.json();
+
+                expect(envelope).toHaveProperty('cipherText');
+                expect(envelope).toHaveProperty('iv');
+                expect(envelope).toHaveProperty('tag');
+                expect(envelope).toHaveProperty('type');
+                expect(envelope).toHaveProperty('contentType');
+                expect(envelope.type).toBe('aes-256-gcm');
+                expect(envelope.contentType).toBe('image/png');
+            });
+        });
+
+        describe('Decrypt verification', () => {
+            it('should decrypt the envelope with the returned key to recover the original binary (base64)', async () => {
+                const postResponse = await request(APP_BASE_URL)
+                    .post(`/api/${API_VERSION}/private`)
+                    .set('X-API-Key', API_KEY)
+                    .attach('file', MINIMAL_PNG, { filename: 'test.png', contentType: 'image/png' })
+                    .field('bucket', 'files')
+                    .expect(201);
+
+                const { uri, decryptionKey } = postResponse.body;
+                const resolvedUri = resolveUri(uri);
+                const getResponse = await fetch(resolvedUri);
+                const envelope: EncryptedEnvelope = await getResponse.json();
+
+                const decrypted = decryptEnvelope(envelope, decryptionKey);
+                const recovered = Buffer.from(decrypted, 'base64');
+
+                expect(recovered.equals(MINIMAL_PNG)).toBe(true);
+            });
+
+            it('should produce a valid SHA-256 hash of the original (unencrypted) file buffer', async () => {
+                const postResponse = await request(APP_BASE_URL)
+                    .post(`/api/${API_VERSION}/private`)
+                    .set('X-API-Key', API_KEY)
+                    .attach('file', MINIMAL_PNG, { filename: 'test.png', contentType: 'image/png' })
+                    .field('bucket', 'files')
+                    .expect(201);
+
+                const expectedHash = computeHash(MINIMAL_PNG);
+                expect(postResponse.body.hash).toBe(expectedHash);
+            });
+        });
+    });
+});

--- a/e2e/private.s3.e2e.test.ts
+++ b/e2e/private.s3.e2e.test.ts
@@ -1,10 +1,8 @@
 import request from 'supertest';
-
+import { v4 as uuidv4 } from 'uuid';
 import { APP_BASE_URL, API_KEY, API_VERSION, resolveUri, computeHash, decryptEnvelope, EncryptedEnvelope } from './helpers';
 
 jest.setTimeout(30000);
-
-const { v4: uuidv4 } = require('uuid');
 
 const testDocument = {
     '@context': ['https://www.w3.org/2018/credentials/v1'],

--- a/e2e/public.s3.e2e.test.ts
+++ b/e2e/public.s3.e2e.test.ts
@@ -1,0 +1,405 @@
+import request from 'supertest';
+import { v4 as uuidv4 } from 'uuid';
+import { APP_BASE_URL, API_KEY, API_VERSION, resolveUri, computeHash } from './helpers';
+
+jest.setTimeout(30000);
+
+const testDocument = {
+    '@context': ['https://www.w3.org/2018/credentials/v1'],
+    type: ['VerifiableCredential'],
+    issuer: 'did:example:123',
+    credentialSubject: {
+        id: 'did:example:456',
+        name: 'Test Subject',
+    },
+};
+
+// Minimal valid PNG (1x1 transparent pixel)
+const MINIMAL_PNG = Buffer.from(
+    '89504e470d0a1a0a0000000d49484452000000010000000108060000001f15c489' +
+    '0000000a49444154789c626000000002000198e195280000000049454e44ae426082',
+    'hex',
+);
+
+// Minimal valid PDF
+const MINIMAL_PDF = Buffer.from(
+    '%PDF-1.0\n1 0 obj<</Type/Catalog/Pages 2 0 R>>endobj\n' +
+    '2 0 obj<</Type/Pages/Kids[3 0 R]/Count 1>>endobj\n' +
+    '3 0 obj<</Type/Page/MediaBox[0 0 3 3]/Parent 2 0 R>>endobj\n' +
+    'xref\n0 4\ntrailer<</Size 4/Root 1 0 R>>\nstartxref\n190\n%%EOF',
+);
+
+// Buffer exceeding 10MB MAX_UPLOAD_SIZE
+const OVERSIZED_FILE = Buffer.alloc(10485761, 0x00);
+
+describe('Public API - S3 E2E Tests', () => {
+    describe('Health Check', () => {
+        it('should return 200 OK for /health-check', async () => {
+            const response = await request(APP_BASE_URL)
+                .get('/health-check')
+                .expect(200);
+
+            expect(response.text).toBe('OK');
+        });
+    });
+
+    describe(`POST /api/${API_VERSION}/public (JSON)`, () => {
+        describe('Authentication', () => {
+            it('should return 401 when API key is missing', async () => {
+                const response = await request(APP_BASE_URL)
+                    .post(`/api/${API_VERSION}/public`)
+                    .send({ bucket: 'verifiable-credentials', data: testDocument })
+                    .expect(401);
+
+                expect(response.body.message).toContain('API key is required');
+            });
+
+            it('should return 401 when API key is invalid', async () => {
+                const response = await request(APP_BASE_URL)
+                    .post(`/api/${API_VERSION}/public`)
+                    .set('X-API-Key', 'wrong-api-key')
+                    .send({ bucket: 'verifiable-credentials', data: testDocument })
+                    .expect(401);
+
+                expect(response.body.message).toContain('Invalid API key');
+            });
+        });
+
+        describe('Validation', () => {
+            it('should return 400 when bucket is missing', async () => {
+                const response = await request(APP_BASE_URL)
+                    .post(`/api/${API_VERSION}/public`)
+                    .set('X-API-Key', API_KEY)
+                    .send({ data: { test: 'data' } })
+                    .expect(400);
+
+                expect(response.body.message).toContain('Bucket is required');
+            });
+
+            it('should return 400 when bucket is not in available list', async () => {
+                const response = await request(APP_BASE_URL)
+                    .post(`/api/${API_VERSION}/public`)
+                    .set('X-API-Key', API_KEY)
+                    .send({ bucket: 'nonexistent', data: { test: 'data' } })
+                    .expect(400);
+
+                expect(response.body.message).toContain('Invalid bucket');
+            });
+
+            it('should return 400 when data is not a JSON object', async () => {
+                const response = await request(APP_BASE_URL)
+                    .post(`/api/${API_VERSION}/public`)
+                    .set('X-API-Key', API_KEY)
+                    .send({ bucket: 'verifiable-credentials', data: 'not-an-object' })
+                    .expect(400);
+
+                expect(response.body.message).toContain('Data must be a JSON object');
+            });
+
+            it('should return 400 when id is not a valid UUID', async () => {
+                const response = await request(APP_BASE_URL)
+                    .post(`/api/${API_VERSION}/public`)
+                    .set('X-API-Key', API_KEY)
+                    .send({ bucket: 'verifiable-credentials', id: 'not-a-uuid', data: { test: 'data' } })
+                    .expect(400);
+
+                expect(response.body.message).toContain('Invalid id');
+            });
+        });
+
+        describe('Storage', () => {
+            it('should return 201 with uri and hash', async () => {
+                const response = await request(APP_BASE_URL)
+                    .post(`/api/${API_VERSION}/public`)
+                    .set('X-API-Key', API_KEY)
+                    .send({ bucket: 'verifiable-credentials', data: testDocument })
+                    .expect(201);
+
+                expect(response.body.uri).toEqual(expect.any(String));
+                expect(response.body.uri.length).toBeGreaterThan(0);
+                expect(response.body.hash).toEqual(expect.any(String));
+                expect(response.body.hash.length).toBeGreaterThan(0);
+            });
+
+            it('should return 201 with custom UUID id', async () => {
+                const customId = '123e4567-e89b-12d3-a456-426614174000';
+                const response = await request(APP_BASE_URL)
+                    .post(`/api/${API_VERSION}/public`)
+                    .set('X-API-Key', API_KEY)
+                    .send({ bucket: 'verifiable-credentials', id: customId, data: testDocument })
+                    .expect(201);
+
+                expect(response.body.uri).toEqual(expect.any(String));
+                expect(response.body.uri).toContain(customId);
+            });
+
+            it('should return 409 when document with same id already exists', async () => {
+                const duplicateId = uuidv4();
+
+                const first = await request(APP_BASE_URL)
+                    .post(`/api/${API_VERSION}/public`)
+                    .set('X-API-Key', API_KEY)
+                    .send({ bucket: 'verifiable-credentials', id: duplicateId, data: testDocument })
+                    .expect(201);
+
+                expect(first.body.uri).toEqual(expect.any(String));
+
+                const second = await request(APP_BASE_URL)
+                    .post(`/api/${API_VERSION}/public`)
+                    .set('X-API-Key', API_KEY)
+                    .send({ bucket: 'verifiable-credentials', id: duplicateId, data: testDocument })
+                    .expect(409);
+
+                expect(second.body.message).toContain('already exists');
+            });
+        });
+
+        describe('Round-trip verification', () => {
+            it('should store JSON and return it unchanged via GET on returned URI', async () => {
+                const response = await request(APP_BASE_URL)
+                    .post(`/api/${API_VERSION}/public`)
+                    .set('X-API-Key', API_KEY)
+                    .send({ bucket: 'verifiable-credentials', data: testDocument })
+                    .expect(201);
+
+                const uri = response.body.uri;
+                const resolvedUrl = resolveUri(uri);
+                const fetchResponse = await fetch(resolvedUrl);
+                const body = await fetchResponse.json();
+
+                expect(body).toEqual(testDocument);
+            });
+
+            it('should produce a valid SHA-256 hash of the stored data', async () => {
+                const response = await request(APP_BASE_URL)
+                    .post(`/api/${API_VERSION}/public`)
+                    .set('X-API-Key', API_KEY)
+                    .send({ bucket: 'verifiable-credentials', data: testDocument })
+                    .expect(201);
+
+                const expectedHash = computeHash(JSON.stringify(testDocument));
+                expect(response.body.hash).toBe(expectedHash);
+            });
+        });
+    });
+
+    describe(`POST /api/${API_VERSION}/public (Binary)`, () => {
+        describe('Authentication', () => {
+            it('should return 401 when API key is missing', async () => {
+                const response = await request(APP_BASE_URL)
+                    .post(`/api/${API_VERSION}/public`)
+                    .attach('file', MINIMAL_PNG, { filename: 'test.png', contentType: 'image/png' })
+                    .field('bucket', 'files')
+                    .expect(401);
+
+                expect(response.body.message).toContain('API key is required');
+            });
+
+            it('should return 401 when API key is invalid', async () => {
+                const response = await request(APP_BASE_URL)
+                    .post(`/api/${API_VERSION}/public`)
+                    .set('X-API-Key', 'wrong-api-key')
+                    .attach('file', MINIMAL_PNG, { filename: 'test.png', contentType: 'image/png' })
+                    .field('bucket', 'files')
+                    .expect(401);
+
+                expect(response.body.message).toContain('Invalid API key');
+            });
+        });
+
+        describe('Validation', () => {
+            it('should return 400 when no file is attached', async () => {
+                const response = await request(APP_BASE_URL)
+                    .post(`/api/${API_VERSION}/public`)
+                    .set('X-API-Key', API_KEY)
+                    .field('bucket', 'files')
+                    .expect(400);
+
+                expect(response.body.message).toContain('File is required for multipart uploads');
+            });
+
+            it('should return 400 when bucket is missing', async () => {
+                const response = await request(APP_BASE_URL)
+                    .post(`/api/${API_VERSION}/public`)
+                    .set('X-API-Key', API_KEY)
+                    .attach('file', MINIMAL_PNG, { filename: 'test.png', contentType: 'image/png' })
+                    .expect(400);
+
+                expect(response.body.message).toContain('Bucket is required');
+            });
+
+            it('should return 400 when bucket is not in available list', async () => {
+                const response = await request(APP_BASE_URL)
+                    .post(`/api/${API_VERSION}/public`)
+                    .set('X-API-Key', API_KEY)
+                    .attach('file', MINIMAL_PNG, { filename: 'test.png', contentType: 'image/png' })
+                    .field('bucket', 'nonexistent-bucket')
+                    .expect(400);
+
+                expect(response.body.message).toContain('Invalid bucket');
+            });
+
+            it('should return 400 when id is not a valid UUID', async () => {
+                const response = await request(APP_BASE_URL)
+                    .post(`/api/${API_VERSION}/public`)
+                    .set('X-API-Key', API_KEY)
+                    .attach('file', MINIMAL_PNG, { filename: 'test.png', contentType: 'image/png' })
+                    .field('bucket', 'files')
+                    .field('id', 'not-a-valid-uuid')
+                    .expect(400);
+
+                expect(response.body.message).toContain('Invalid id');
+            });
+
+            it('should reject when MIME type is not in allow-list', async () => {
+                const response = await request(APP_BASE_URL)
+                    .post(`/api/${API_VERSION}/public`)
+                    .set('X-API-Key', API_KEY)
+                    .attach('file', Buffer.from('not a real zip'), { filename: 'test.zip', contentType: 'application/zip' })
+                    .field('bucket', 'files');
+
+                expect(response.status).toBe(400);
+                expect(response.body.message).toContain('not allowed');
+            });
+
+            it('should return 413 when file exceeds maximum allowed size', async () => {
+                const response = await request(APP_BASE_URL)
+                    .post(`/api/${API_VERSION}/public`)
+                    .set('X-API-Key', API_KEY)
+                    .attach('file', OVERSIZED_FILE, { filename: 'large.png', contentType: 'image/png' })
+                    .field('bucket', 'files')
+                    .expect(413);
+
+                expect(response.body.message).toContain('exceeds the maximum allowed size');
+            });
+        });
+
+        describe('Storage', () => {
+            it('should return 201 when uploading a valid PNG', async () => {
+                const response = await request(APP_BASE_URL)
+                    .post(`/api/${API_VERSION}/public`)
+                    .set('X-API-Key', API_KEY)
+                    .attach('file', MINIMAL_PNG, { filename: 'test.png', contentType: 'image/png' })
+                    .field('bucket', 'files')
+                    .expect(201);
+
+                expect(response.body.uri).toEqual(expect.any(String));
+                expect(response.body.uri.length).toBeGreaterThan(0);
+                expect(response.body.hash).toEqual(expect.any(String));
+                expect(response.body.hash.length).toBeGreaterThan(0);
+            });
+
+            it('should return 201 when uploading a valid PDF', async () => {
+                const response = await request(APP_BASE_URL)
+                    .post(`/api/${API_VERSION}/public`)
+                    .set('X-API-Key', API_KEY)
+                    .attach('file', MINIMAL_PDF, { filename: 'test.pdf', contentType: 'application/pdf' })
+                    .field('bucket', 'files')
+                    .expect(201);
+
+                expect(response.body.uri).toEqual(expect.any(String));
+                expect(response.body.uri.length).toBeGreaterThan(0);
+                expect(response.body.hash).toEqual(expect.any(String));
+                expect(response.body.hash.length).toBeGreaterThan(0);
+            });
+
+            it('should return 201 when uploading a valid JPEG', async () => {
+                const response = await request(APP_BASE_URL)
+                    .post(`/api/${API_VERSION}/public`)
+                    .set('X-API-Key', API_KEY)
+                    .attach('file', Buffer.from('fake-jpeg-content'), { filename: 'test.jpg', contentType: 'image/jpeg' })
+                    .field('bucket', 'files')
+                    .expect(201);
+
+                expect(response.body.uri).toEqual(expect.any(String));
+                expect(response.body.uri.length).toBeGreaterThan(0);
+                expect(response.body.hash).toEqual(expect.any(String));
+                expect(response.body.hash.length).toBeGreaterThan(0);
+            });
+
+            it('should return 201 with a custom UUID id', async () => {
+                const customId = uuidv4();
+                const response = await request(APP_BASE_URL)
+                    .post(`/api/${API_VERSION}/public`)
+                    .set('X-API-Key', API_KEY)
+                    .attach('file', MINIMAL_PNG, { filename: 'test.png', contentType: 'image/png' })
+                    .field('bucket', 'files')
+                    .field('id', customId)
+                    .expect(201);
+
+                expect(response.body.uri).toEqual(expect.any(String));
+                expect(response.body.uri).toContain(customId);
+            });
+
+            it('should return 409 when file with same id already exists', async () => {
+                const duplicateId = uuidv4();
+
+                const first = await request(APP_BASE_URL)
+                    .post(`/api/${API_VERSION}/public`)
+                    .set('X-API-Key', API_KEY)
+                    .attach('file', MINIMAL_PNG, { filename: 'test.png', contentType: 'image/png' })
+                    .field('bucket', 'files')
+                    .field('id', duplicateId)
+                    .expect(201);
+
+                expect(first.body.uri).toEqual(expect.any(String));
+
+                const second = await request(APP_BASE_URL)
+                    .post(`/api/${API_VERSION}/public`)
+                    .set('X-API-Key', API_KEY)
+                    .attach('file', MINIMAL_PNG, { filename: 'test.png', contentType: 'image/png' })
+                    .field('bucket', 'files')
+                    .field('id', duplicateId)
+                    .expect(409);
+
+                expect(second.body.message).toContain('already exists');
+            });
+        });
+
+        describe('Round-trip verification', () => {
+            it('should store a PNG and return the identical binary via GET on returned URI', async () => {
+                const response = await request(APP_BASE_URL)
+                    .post(`/api/${API_VERSION}/public`)
+                    .set('X-API-Key', API_KEY)
+                    .attach('file', MINIMAL_PNG, { filename: 'test.png', contentType: 'image/png' })
+                    .field('bucket', 'files')
+                    .expect(201);
+
+                const uri = response.body.uri;
+                const resolvedUrl = resolveUri(uri);
+                const fetchResponse = await fetch(resolvedUrl);
+                const buf = Buffer.from(await fetchResponse.arrayBuffer());
+
+                expect(buf.equals(MINIMAL_PNG)).toBe(true);
+            });
+
+            it('should store a PDF and return the identical binary via GET on returned URI', async () => {
+                const response = await request(APP_BASE_URL)
+                    .post(`/api/${API_VERSION}/public`)
+                    .set('X-API-Key', API_KEY)
+                    .attach('file', MINIMAL_PDF, { filename: 'test.pdf', contentType: 'application/pdf' })
+                    .field('bucket', 'files')
+                    .expect(201);
+
+                const uri = response.body.uri;
+                const resolvedUrl = resolveUri(uri);
+                const fetchResponse = await fetch(resolvedUrl);
+                const buf = Buffer.from(await fetchResponse.arrayBuffer());
+
+                expect(buf.equals(MINIMAL_PDF)).toBe(true);
+            });
+
+            it('should produce a valid SHA-256 hash of the stored file', async () => {
+                const response = await request(APP_BASE_URL)
+                    .post(`/api/${API_VERSION}/public`)
+                    .set('X-API-Key', API_KEY)
+                    .attach('file', MINIMAL_PNG, { filename: 'test.png', contentType: 'image/png' })
+                    .field('bucket', 'files')
+                    .expect(201);
+
+                const expectedHash = computeHash(MINIMAL_PNG);
+                expect(response.body.hash).toBe(expectedHash);
+            });
+        });
+    });
+});

--- a/package.json
+++ b/package.json
@@ -10,7 +10,6 @@
         "start": "node dist/index.js",
         "test": "jest --testPathIgnorePatterns=/e2e/",
         "test:e2e": "docker compose -f docker-compose.e2e.yml up -d --build --wait && jest --testMatch='**/e2e/**/*.e2e.test.ts' --coverage=false; EXIT_CODE=$?; docker compose -f docker-compose.e2e.yml down -v; exit $EXIT_CODE",
-        "test:all": "jest --testPathIgnorePatterns=/e2e/",
         "test:ci": "jest --ci --json --coverage --testLocationInResults --outputFile=report.json --testPathIgnorePatterns=/e2e/",
         "test:e2e:ci": "docker compose -f docker-compose.e2e.yml up -d --build --wait && jest --ci --testMatch='**/e2e/**/*.e2e.test.ts' --coverage=false; EXIT_CODE=$?; docker compose -f docker-compose.e2e.yml down -v; exit $EXIT_CODE",
         "watch:build": "webpack --watch --mode development",

--- a/package.json
+++ b/package.json
@@ -9,10 +9,10 @@
         "postinstall": "husky",
         "start": "node dist/index.js",
         "test": "jest --testPathIgnorePatterns=/e2e/",
-        "test:e2e": "jest --testMatch='**/e2e/**/*.e2e.test.ts'",
-        "test:all": "jest",
+        "test:e2e": "docker compose -f docker-compose.e2e.yml up -d --build --wait && jest --testMatch='**/e2e/**/*.e2e.test.ts' --coverage=false; EXIT_CODE=$?; docker compose -f docker-compose.e2e.yml down -v; exit $EXIT_CODE",
+        "test:all": "jest --testPathIgnorePatterns=/e2e/",
         "test:ci": "jest --ci --json --coverage --testLocationInResults --outputFile=report.json --testPathIgnorePatterns=/e2e/",
-        "test:e2e:ci": "jest --ci --testMatch='**/e2e/**/*.e2e.test.ts' --coverage=false",
+        "test:e2e:ci": "docker compose -f docker-compose.e2e.yml up -d --build --wait && jest --ci --testMatch='**/e2e/**/*.e2e.test.ts' --coverage=false; EXIT_CODE=$?; docker compose -f docker-compose.e2e.yml down -v; exit $EXIT_CODE",
         "watch:build": "webpack --watch --mode development",
         "watch:server": "nodemon \"./dist/server.js\" --watch \"./dist\"",
         "release:doc": "node scripts/release-doc.js"

--- a/src/routes/private/controller.ts
+++ b/src/routes/private/controller.ts
@@ -33,10 +33,11 @@ export const storePrivate: RequestHandler = async (req, res) => {
         let response;
 
         if (req.file) {
-            tempPath = path.resolve(req.file.path);
-            if (!tempPath.startsWith(UPLOAD_DIR + path.sep)) {
+            const resolvedPath = path.resolve(req.file.path);
+            if (!resolvedPath.startsWith(UPLOAD_DIR + path.sep)) {
                 throw new BadRequestError('Invalid upload path.');
             }
+            tempPath = resolvedPath;
             const fileBuffer = await fs.promises.readFile(tempPath);
 
             response = await privateService.encryptAndStoreFile(storageService, cryptographyService, {
@@ -65,7 +66,7 @@ export const storePrivate: RequestHandler = async (req, res) => {
             message: 'An unexpected error occurred while storing private data.',
         });
     } finally {
-        if (tempPath) {
+        if (tempPath && tempPath.startsWith(UPLOAD_DIR + path.sep)) {
             try {
                 await fs.promises.unlink(tempPath);
             } catch (cleanupErr: any) {

--- a/src/routes/public/controller.ts
+++ b/src/routes/public/controller.ts
@@ -33,10 +33,11 @@ export const storePublic: RequestHandler = async (req, res) => {
         let response;
 
         if (req.file) {
-            tempPath = path.resolve(req.file.path);
-            if (!tempPath.startsWith(UPLOAD_DIR + path.sep)) {
+            const resolvedPath = path.resolve(req.file.path);
+            if (!resolvedPath.startsWith(UPLOAD_DIR + path.sep)) {
                 throw new BadRequestError('Invalid upload path.');
             }
+            tempPath = resolvedPath;
             const fileBuffer = await fs.promises.readFile(tempPath);
 
             response = await publicService.storeFile(storageService, cryptoService, {
@@ -65,7 +66,7 @@ export const storePublic: RequestHandler = async (req, res) => {
             message: 'An unexpected error occurred while storing the resource.',
         });
     } finally {
-        if (tempPath) {
+        if (tempPath && tempPath.startsWith(UPLOAD_DIR + path.sep)) {
             try {
                 await fs.promises.unlink(tempPath);
             } catch (cleanupErr: any) {

--- a/src/swagger/swagger-url.test.ts
+++ b/src/swagger/swagger-url.test.ts
@@ -1,6 +1,6 @@
 import request from 'supertest';
 
-const { apiVersion: API_VERSION } = require('../version.json');
+const { apiVersion: API_VERSION } = require('../../version.json');
 
 const buildConfigMock = (overrides: Record<string, unknown> = {}) => ({
     API_VERSION: API_VERSION,
@@ -19,12 +19,12 @@ const buildConfigMock = (overrides: Record<string, unknown> = {}) => ({
 });
 
 const getSwaggerInitResponse = async (configOverrides: Record<string, unknown> = {}) => {
-    jest.doMock('../src/config', () => buildConfigMock(configOverrides));
-    const { app } = await import('../src/app');
+    jest.doMock('../config', () => buildConfigMock(configOverrides));
+    const { app } = await import('../app');
     return request(app).get('/api-docs/swagger-ui-init.js').expect(200);
 };
 
-describe('Swagger URL E2E Tests', () => {
+describe('Swagger URL Tests', () => {
     afterEach(() => {
         jest.resetModules();
         jest.restoreAllMocks();


### PR DESCRIPTION
This PR replaces all mocked E2E tests with a fully containerised test suite that exercises real storage operations against MinIO (S3-compatible). Both the app and MinIO run in Docker; tests perform full round-trip verification, including encrypted content decryption for private paths. 57 E2E tests pass across public and private endpoints.

Depends on #83.

## Changes

- **Docker Compose**: Add `docker-compose.e2e.yml` with MinIO, bucket init container, and app services
- **E2E tests**: 28 public + 29 private test cases covering auth, validation, storage, round-trip GET, and decrypt verification
- **Helpers**: Shared `e2e/helpers.ts` with URI rewriting, AES-256-GCM decryption, and SHA-256 hash utilities
- **Swagger tests**: Move swagger-url tests from E2E to unit test suite (`src/swagger/`)
- **Scripts**: `test:e2e` and `test:e2e:ci` now wrap Docker Compose lifecycle; `test:all` excludes E2E
- **CI**: Remove hardcoded `API_KEY` env var (now in Docker Compose)
- **Docker**: Add `.dockerignore` to optimise image builds

## Test plan
- [x] `yarn test:e2e` starts containers, runs 57 E2E tests, tears down (all pass)
- [x] Full round-trip verification: upload, GET returned URI, compare content
- [x] Private decrypt round-trip: upload, GET envelope, decrypt, verify original content
- [x] 150 unit tests still pass (including migrated swagger-url tests)
- [x] No `jest.mock()` calls in any E2E test file