### PR TITLE
chore: update references from project-identity-resolver to project-storage-service

### DIFF
--- a/.github/workflows/package-next.yml
+++ b/.github/workflows/package-next.yml
@@ -24,7 +24,9 @@ jobs:
               id: meta
               uses: docker/metadata-action@v5
               with:
-                  images: ghcr.io/${{github.repository}}
+                  images: |
+                      ghcr.io/${{github.repository}}
+                      ghcr.io/uncefact/project-storage-service
                   tags: |
                       type=raw,value=next
                       type=sha,prefix=next-,format=short

--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -36,7 +36,9 @@ jobs:
               id: meta
               uses: docker/metadata-action@v5
               with:
-                  images: ghcr.io/${{github.repository}}
+                  images: |
+                      ghcr.io/${{github.repository}}
+                      ghcr.io/uncefact/project-storage-service
                   tags: |
                       type=raw,value=${{ steps.get_version.outputs.version }}
                       type=raw,value=latest

--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ The response includes:
 
 **Save this key securely** — it's the only way to decrypt your data later.
 
-→ [Learn more about storage options](https://uncefact.github.io/project-identity-resolver/docs/storage-options)
+→ [Learn more about storage options](https://uncefact.github.io/project-storage-service/docs/storage-options)
 
 ## Prerequisites
 
@@ -271,7 +271,7 @@ If the API key is missing or invalid, the service will return a `401 Unauthorize
 
 ## Docker Images
 
-Pre-built Docker images are available on [GitHub Container Registry](https://github.com/uncefact/project-identity-resolver/pkgs/container/project-identity-resolver).
+Pre-built Docker images are available on [GitHub Container Registry](https://github.com/uncefact/project-storage-service/pkgs/container/project-storage-service).
 
 Images support `linux/amd64` and `linux/arm64` architectures (Intel/AMD and Apple Silicon/ARM).
 
@@ -279,13 +279,13 @@ Images support `linux/amd64` and `linux/arm64` architectures (Intel/AMD and Appl
 
 ```bash
 # Pull a specific version (e.g., 2.1.0)
-docker pull ghcr.io/uncefact/project-identity-resolver:2.1.0
+docker pull ghcr.io/uncefact/project-storage-service:2.1.0
 
 # Or pull the latest release
-docker pull ghcr.io/uncefact/project-identity-resolver:latest
+docker pull ghcr.io/uncefact/project-storage-service:latest
 
 # Or pull the latest development image from the next branch
-docker pull ghcr.io/uncefact/project-identity-resolver:next
+docker pull ghcr.io/uncefact/project-storage-service:next
 ```
 
 ### Building and Running Locally with Docker

--- a/documentation/ci/package.md
+++ b/documentation/ci/package.md
@@ -38,10 +38,10 @@ Images are built for multiple architectures:
 
 ```bash
 # Latest release by version
-docker pull ghcr.io/uncefact/project-identity-resolver:1.1.0
+docker pull ghcr.io/uncefact/project-storage-service:1.1.0
 
 # Or use latest tag
-docker pull ghcr.io/uncefact/project-identity-resolver:latest
+docker pull ghcr.io/uncefact/project-storage-service:latest
 ```
 
 ## Workflow Steps

--- a/documentation/docs/getting-started/index.md
+++ b/documentation/docs/getting-started/index.md
@@ -12,7 +12,7 @@ Before you begin, ensure you have installed:
 
 ## Basic Setup
 
-1. Clone the [Storage Service repository](https://github.com/uncefact/project-identity-resolver)
+1. Clone the [Storage Service repository](https://github.com/uncefact/project-storage-service)
 2. Copy `.env.example` to `.env`
 3. Configure your environment variables (see [Configuration section](/docs/getting-started/#configuration))
 4. Install dependencies:

--- a/documentation/docs/installation/index.md
+++ b/documentation/docs/installation/index.md
@@ -5,7 +5,7 @@ title: Installation
 
 ## Local Installation
 
-Clone the [repository](https://github.com/uncefact/project-identity-resolver), install dependencies and run:
+Clone the [repository](https://github.com/uncefact/project-storage-service), install dependencies and run:
 
 ```bash
 yarn install
@@ -14,19 +14,19 @@ yarn dev
 
 ## Using Pre-built Docker Images
 
-Pre-built Docker images are available on [GitHub Container Registry](https://github.com/uncefact/project-identity-resolver/pkgs/container/project-identity-resolver).
+Pre-built Docker images are available on [GitHub Container Registry](https://github.com/uncefact/project-storage-service/pkgs/container/project-storage-service).
 
 Images support `linux/amd64` and `linux/arm64` architectures (Intel/AMD and Apple Silicon/ARM).
 
 ```bash
 # Pull the latest image
-docker pull ghcr.io/uncefact/project-identity-resolver:latest
+docker pull ghcr.io/uncefact/project-storage-service:latest
 
 # Alternatively, pull a specific version (e.g., 2.0.1)
-# docker pull ghcr.io/uncefact/project-identity-resolver:2.0.1
+# docker pull ghcr.io/uncefact/project-storage-service:2.0.1
 
 # Or pull the latest development image from the next branch
-# docker pull ghcr.io/uncefact/project-identity-resolver:next
+# docker pull ghcr.io/uncefact/project-storage-service:next
 
 # Copy and configure your environment file
 cp .env.example .env
@@ -35,7 +35,7 @@ cp .env.example .env
 # Run the container (replace the tag if you pulled a different image above)
 docker run -d --env-file .env -p 3333:3333 \
   -v $(pwd)/uploads:/app/src/uploads:rw \
-  ghcr.io/uncefact/project-identity-resolver:latest
+  ghcr.io/uncefact/project-storage-service:latest
 ```
 
 ## Building Docker Locally

--- a/documentation/docusaurus.config.ts
+++ b/documentation/docusaurus.config.ts
@@ -13,7 +13,7 @@ const config: Config = {
     baseUrl,
 
     organizationName: 'uncefact',
-    projectName: 'project-identity-resolver',
+    projectName: 'project-storage-service',
 
     onBrokenLinks: 'throw',
     onBrokenMarkdownLinks: 'warn',
@@ -33,7 +33,7 @@ const config: Config = {
             {
                 docs: {
                     sidebarPath: './sidebars.ts',
-                    editUrl: 'https://github.com/uncefact/project-identity-resolver/tree/next',
+                    editUrl: 'https://github.com/uncefact/project-storage-service/tree/next',
                     routeBasePath: 'docs',
                     includeCurrentVersion: false,
                 },
@@ -51,7 +51,7 @@ const config: Config = {
 
     themeConfig: {
         slackLink: 'https://join.slack.com/t/uncefact/shared_invite/zt-1d7hd0js1-sS1Xgk8DawQD9VgRvy1QHQ',
-        repoLink: 'https://github.com/uncefact/project-identity-resolver',
+        repoLink: 'https://github.com/uncefact/project-storage-service',
         colorMode: {
             disableSwitch: true,
         },
@@ -81,7 +81,7 @@ const config: Config = {
                 },
                 { to: '/docs/features/', label: 'Features', position: 'right' },
                 {
-                    to: 'https://github.com/uncefact/project-identity-resolver',
+                    to: 'https://github.com/uncefact/project-storage-service',
                     label: 'Contribute',
                     position: 'right',
                 },
@@ -92,7 +92,7 @@ const config: Config = {
                     className: 'navbar-slack-link',
                 },
                 {
-                    href: 'https://github.com/uncefact/project-identity-resolver',
+                    href: 'https://github.com/uncefact/project-storage-service',
                     html: '<svg class="icon"><use xlink:href="#github"></use></svg><span class="menu-item-name">Github</span>',
                     className: 'navbar-github-link',
                     position: 'right',


### PR DESCRIPTION
This PR updates all internal references from `project-identity-resolver` to `project-storage-service` ahead of the GitHub repository rename. Docker image workflows now dual-publish to both the old and new GHCR container names, ensuring downstream consumers can pull from either name during the transition period.

Versioned documentation snapshots and CHANGELOG are intentionally left unchanged as historical records. GitHub's automatic URL redirects will cover any old repository links after the rename.

Closes #31

## Test plan
- [x] Unit tests pass (147/147)
- [x] App builds successfully
- [x] Lint passes (0 errors)
- [x] Documentation references point to `project-storage-service`
- [x] CI workflows dual-publish to both old and new container names
- [x] Versioned docs and CHANGELOG left as-is (historical snapshots)