### PR TITLE
feat(storage): add PUBLIC_URL override for document URIs

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -26,6 +26,7 @@ AVAILABLE_BUCKETS=documents,files
 # S3_REGION=ap-southeast-2           # Required for AWS S3, optional with custom endpoint
 # S3_ENDPOINT=http://localhost:9000  # Custom endpoint for S3-compatible providers
 # S3_FORCE_PATH_STYLE=true           # Required for MinIO, Cloudflare R2
+# S3_PUBLIC_URL=https://cdn.example.com  # Override URI returned to clients (uploads still use S3_ENDPOINT)
 # AWS_ACCESS_KEY_ID=your-access-key-id
 # AWS_SECRET_ACCESS_KEY=your-secret-access-key
 

--- a/.env.example
+++ b/.env.example
@@ -26,7 +26,7 @@ AVAILABLE_BUCKETS=documents,files
 # S3_REGION=ap-southeast-2           # Required for AWS S3, optional with custom endpoint
 # S3_ENDPOINT=http://localhost:9000  # Custom endpoint for S3-compatible providers
 # S3_FORCE_PATH_STYLE=true           # Required for MinIO, Cloudflare R2
-# S3_PUBLIC_URL=https://cdn.example.com  # Override URI returned to clients (uploads still use S3_ENDPOINT)
+# S3_PUBLIC_URL=https://cdn.example.com  # Override base URL for URIs returned to clients
 # AWS_ACCESS_KEY_ID=your-access-key-id
 # AWS_SECRET_ACCESS_KEY=your-secret-access-key
 

--- a/.env.example
+++ b/.env.example
@@ -17,6 +17,12 @@ LOCAL_DIRECTORY=uploads
 DEFAULT_BUCKET=documents
 AVAILABLE_BUCKETS=documents,files
 
+# Public URL Override
+# When using a CDN or custom domain, override the base URL for document URIs returned to clients.
+# Uploads still go to the configured storage provider. Only the URI in API responses changes.
+# Applies to: aws, gcp (ignored for local storage)
+# PUBLIC_URL=https://cdn.example.com
+
 # Cloud Provider Credentials (if using cloud storage)
 
 # Google Cloud Platform
@@ -26,7 +32,6 @@ AVAILABLE_BUCKETS=documents,files
 # S3_REGION=ap-southeast-2           # Required for AWS S3, optional with custom endpoint
 # S3_ENDPOINT=http://localhost:9000  # Custom endpoint for S3-compatible providers
 # S3_FORCE_PATH_STYLE=true           # Required for MinIO, Cloudflare R2
-# S3_PUBLIC_URL=https://cdn.example.com  # Override base URL for URIs returned to clients
 # AWS_ACCESS_KEY_ID=your-access-key-id
 # AWS_SECRET_ACCESS_KEY=your-secret-access-key
 

--- a/documentation/docs/deployment-guide/configuration/index.md
+++ b/documentation/docs/deployment-guide/configuration/index.md
@@ -24,10 +24,11 @@ The service will not start without `API_KEY` set.
 
 ## Storage Configuration
 
-| Variable          | Description                                 | Default   |
-| ----------------- | ------------------------------------------- | --------- |
-| `STORAGE_TYPE`    | Storage provider (`local`, `gcp`, or `aws`) | `local`   |
-| `LOCAL_DIRECTORY` | Directory for local file storage            | `uploads` |
+| Variable          | Description                                                                                  | Default     |
+| ----------------- | -------------------------------------------------------------------------------------------- | ----------- |
+| `STORAGE_TYPE`    | Storage provider (`local`, `gcp`, or `aws`)                                                  | `local`     |
+| `LOCAL_DIRECTORY` | Directory for local file storage                                                             | `uploads`   |
+| `PUBLIC_URL`      | Override base URL for document URIs returned to clients. Applies to `aws` and `gcp` storage. | _(not set)_ |
 
 For cloud storage provider configuration, see [Storage Providers](../storage-providers/).
 

--- a/documentation/docs/deployment-guide/storage-providers/index.md
+++ b/documentation/docs/deployment-guide/storage-providers/index.md
@@ -95,10 +95,50 @@ AVAILABLE_BUCKETS=documents,files
 
 ## S3 Configuration Reference
 
-| Variable                | Required         | Description                                                               |
-| ----------------------- | ---------------- | ------------------------------------------------------------------------- |
-| `S3_REGION`             | Yes (for AWS S3) | AWS region. Not required when using a custom endpoint.                    |
-| `S3_ENDPOINT`           | No               | Custom endpoint URL for S3-compatible providers.                          |
-| `S3_FORCE_PATH_STYLE`   | No               | Set to `true` for path-style URLs (required for MinIO and Cloudflare R2). |
-| `AWS_ACCESS_KEY_ID`     | Yes              | Access key for authentication.                                            |
-| `AWS_SECRET_ACCESS_KEY` | Yes              | Secret key for authentication.                                            |
+| Variable                | Required         | Description                                                                                              |
+| ----------------------- | ---------------- | -------------------------------------------------------------------------------------------------------- |
+| `S3_REGION`             | Yes (for AWS S3) | AWS region. Not required when using a custom endpoint.                                                   |
+| `S3_ENDPOINT`           | No               | Custom endpoint URL for S3-compatible providers.                                                         |
+| `S3_FORCE_PATH_STYLE`   | No               | Set to `true` for path-style URLs (required for MinIO and Cloudflare R2).                                |
+| `S3_PUBLIC_URL`         | No               | Base URL for public document URIs (see [Custom Public URL](#custom-public-url-for-document-uris) below). |
+| `AWS_ACCESS_KEY_ID`     | Yes              | Access key for authentication.                                                                           |
+| `AWS_SECRET_ACCESS_KEY` | Yes              | Secret key for authentication.                                                                           |
+
+## Custom Public URL for Document URIs
+
+By default, the service constructs public document URIs from `S3_ENDPOINT` (or the AWS S3 default). This means the URI returned to clients exposes the raw storage endpoint:
+
+```
+https://my-bucket.syd1.digitaloceanspaces.com/123e4567.json
+```
+
+If you place a CDN or custom domain in front of your storage bucket, you can set `S3_PUBLIC_URL` to override **only the URI returned to clients**. Uploads and all other S3 API operations continue to use `S3_ENDPOINT` as normal.
+
+```
+https://documents.example.com/123e4567.json
+```
+
+:::info How it works
+`S3_PUBLIC_URL` changes **only** the URI returned in API responses. It does not affect where files are uploaded to or how the service communicates with your storage provider. The upload path remains: **Service → `S3_ENDPOINT` → Storage Provider**. The response URI becomes: **`S3_PUBLIC_URL`/key**.
+:::
+
+### Example: DigitalOcean Spaces with CDN
+
+```env
+STORAGE_TYPE=aws
+S3_ENDPOINT=https://syd1.digitaloceanspaces.com
+S3_PUBLIC_URL=https://documents.example.com
+AWS_ACCESS_KEY_ID=your-do-access-key-id
+AWS_SECRET_ACCESS_KEY=your-do-secret-access-key
+AVAILABLE_BUCKETS=documents,files
+```
+
+In this configuration:
+
+- Files are uploaded to DigitalOcean Spaces via `S3_ENDPOINT`
+- The URI returned to clients uses `S3_PUBLIC_URL`: `https://documents.example.com/{key}`
+- Your CDN custom domain (`documents.example.com`) should be configured to serve content from the Spaces bucket
+
+:::note
+When `S3_PUBLIC_URL` is set, the bucket name is **not** included in the generated URI. This assumes your CDN or custom domain already points to a specific bucket.
+:::

--- a/documentation/docs/deployment-guide/storage-providers/index.md
+++ b/documentation/docs/deployment-guide/storage-providers/index.md
@@ -119,7 +119,7 @@ https://documents.example.com/123e4567.json
 ```
 
 :::info How it works
-`S3_PUBLIC_URL` changes **only** the URI returned in API responses. It does not affect where files are uploaded to or how the service communicates with your storage provider. The upload path remains: **Service → `S3_ENDPOINT` → Storage Provider**. The response URI becomes: **`S3_PUBLIC_URL`/key**.
+`S3_PUBLIC_URL` changes **only** the URI returned in API responses. It does not affect where files are uploaded to or how the service communicates with your storage provider. The upload path remains unchanged, whether that uses `S3_ENDPOINT` or the default AWS S3 regional endpoint. The response URI becomes: **`S3_PUBLIC_URL`/key**.
 :::
 
 ### Example: DigitalOcean Spaces with CDN
@@ -140,5 +140,7 @@ In this configuration:
 - Your CDN custom domain (`documents.example.com`) should be configured to serve content from the Spaces bucket
 
 :::note
-When `S3_PUBLIC_URL` is set, the bucket name is **not** included in the generated URI. This assumes your CDN or custom domain already points to a specific bucket.
+When `S3_PUBLIC_URL` is set, the bucket name is **not** included in the generated URI. This assumes your CDN or custom domain already points to a specific bucket. If you use multiple buckets (via `AVAILABLE_BUCKETS`), all generated URIs will share the same `S3_PUBLIC_URL` base.
+
+Only the origin (protocol, hostname, and port) of `S3_PUBLIC_URL` is used. Any path component (e.g. `https://cdn.example.com/subpath`) is ignored.
 :::

--- a/src/config.ts
+++ b/src/config.ts
@@ -35,6 +35,7 @@ export const LOCAL_DIRECTORY = process.env.LOCAL_DIRECTORY || 'uploads';
 export const S3_REGION = process.env.S3_REGION;
 export const S3_ENDPOINT = process.env.S3_ENDPOINT;
 export const S3_FORCE_PATH_STYLE = process.env.S3_FORCE_PATH_STYLE === 'true';
+export const S3_PUBLIC_URL = process.env.S3_PUBLIC_URL;
 
 // Runtime getter for API_KEY to ensure it's evaluated at runtime, not build time
 export const getApiKey = () => process.env.API_KEY;

--- a/src/config.ts
+++ b/src/config.ts
@@ -31,11 +31,13 @@ export const AVAILABLE_BUCKETS = process.env.AVAILABLE_BUCKETS
 export const STORAGE_TYPE = process.env.STORAGE_TYPE || 'local'; // local | gcp | aws
 export const LOCAL_DIRECTORY = process.env.LOCAL_DIRECTORY || 'uploads';
 
+// Public URL override for document URIs (used when STORAGE_TYPE=aws or STORAGE_TYPE=gcp)
+export const PUBLIC_URL = process.env.PUBLIC_URL;
+
 // S3-compatible storage configuration (used when STORAGE_TYPE=aws)
 export const S3_REGION = process.env.S3_REGION;
 export const S3_ENDPOINT = process.env.S3_ENDPOINT;
 export const S3_FORCE_PATH_STYLE = process.env.S3_FORCE_PATH_STYLE === 'true';
-export const S3_PUBLIC_URL = process.env.S3_PUBLIC_URL;
 
 // Runtime getter for API_KEY to ensure it's evaluated at runtime, not build time
 export const getApiKey = () => process.env.API_KEY;

--- a/src/config.ts
+++ b/src/config.ts
@@ -34,6 +34,22 @@ export const LOCAL_DIRECTORY = process.env.LOCAL_DIRECTORY || 'uploads';
 // Public URL override for document URIs (used when STORAGE_TYPE=aws or STORAGE_TYPE=gcp)
 export const PUBLIC_URL = process.env.PUBLIC_URL;
 
+/**
+ * Returns a public URI using PUBLIC_URL if set, otherwise null.
+ * Only the origin (protocol, hostname, port) of PUBLIC_URL is used; path components are ignored.
+ */
+export const generatePublicUri = (key: string): string | null => {
+    if (!PUBLIC_URL) return null;
+
+    let url: URL;
+    try {
+        url = new URL(PUBLIC_URL);
+    } catch {
+        throw new Error(`Invalid PUBLIC_URL format: "${PUBLIC_URL}" is not a valid URL`);
+    }
+    return `${url.origin}/${key}`;
+};
+
 // S3-compatible storage configuration (used when STORAGE_TYPE=aws)
 export const S3_REGION = process.env.S3_REGION;
 export const S3_ENDPOINT = process.env.S3_ENDPOINT;

--- a/src/services/storage/aws.test.ts
+++ b/src/services/storage/aws.test.ts
@@ -2,6 +2,19 @@ import { S3Client, HeadObjectCommand, PutObjectCommand } from '@aws-sdk/client-s
 
 const mockSend = jest.fn();
 
+const createGeneratePublicUri =
+    (publicUrl: string | undefined) =>
+    (key: string): string | null => {
+        if (!publicUrl) return null;
+        let url: URL;
+        try {
+            url = new URL(publicUrl);
+        } catch {
+            throw new Error(`Invalid PUBLIC_URL format: "${publicUrl}" is not a valid URL`);
+        }
+        return `${url.origin}/${key}`;
+    };
+
 jest.mock('@aws-sdk/client-s3', () => {
     return {
         S3Client: jest.fn().mockImplementation(() => ({
@@ -28,7 +41,7 @@ describe('AWSStorageService', () => {
                 S3_REGION: 'ap-southeast-2',
                 S3_ENDPOINT: undefined,
                 S3_FORCE_PATH_STYLE: false,
-                PUBLIC_URL: undefined,
+                generatePublicUri: createGeneratePublicUri(undefined),
             }));
         });
 
@@ -105,7 +118,7 @@ describe('AWSStorageService', () => {
                 S3_REGION: undefined,
                 S3_ENDPOINT: 'http://localhost:9000',
                 S3_FORCE_PATH_STYLE: true,
-                PUBLIC_URL: undefined,
+                generatePublicUri: createGeneratePublicUri(undefined),
             }));
         });
 
@@ -131,7 +144,7 @@ describe('AWSStorageService', () => {
                 S3_REGION: undefined,
                 S3_ENDPOINT: 'https://syd1.digitaloceanspaces.com',
                 S3_FORCE_PATH_STYLE: false,
-                PUBLIC_URL: undefined,
+                generatePublicUri: createGeneratePublicUri(undefined),
             }));
         });
 
@@ -157,7 +170,7 @@ describe('AWSStorageService', () => {
                 S3_REGION: undefined,
                 S3_ENDPOINT: 'https://syd1.digitaloceanspaces.com',
                 S3_FORCE_PATH_STYLE: false,
-                PUBLIC_URL: 'https://documents.labs.pyx.io',
+                generatePublicUri: createGeneratePublicUri('https://documents.labs.pyx.io'),
             }));
             mockSend.mockResolvedValueOnce({});
             const { AWSStorageService } = require('./aws');
@@ -176,7 +189,7 @@ describe('AWSStorageService', () => {
                 S3_REGION: undefined,
                 S3_ENDPOINT: 'https://syd1.digitaloceanspaces.com',
                 S3_FORCE_PATH_STYLE: false,
-                PUBLIC_URL: 'https://documents.labs.pyx.io/',
+                generatePublicUri: createGeneratePublicUri('https://documents.labs.pyx.io/'),
             }));
             mockSend.mockResolvedValueOnce({});
             const { AWSStorageService } = require('./aws');
@@ -195,7 +208,7 @@ describe('AWSStorageService', () => {
                 S3_REGION: undefined,
                 S3_ENDPOINT: 'https://syd1.digitaloceanspaces.com',
                 S3_FORCE_PATH_STYLE: false,
-                PUBLIC_URL: 'https://cdn.example.com/some/subpath',
+                generatePublicUri: createGeneratePublicUri('https://cdn.example.com/some/subpath'),
             }));
             mockSend.mockResolvedValueOnce({});
             const { AWSStorageService } = require('./aws');
@@ -215,7 +228,7 @@ describe('AWSStorageService', () => {
                 S3_REGION: undefined,
                 S3_ENDPOINT: 'http://localhost:9000',
                 S3_FORCE_PATH_STYLE: true,
-                PUBLIC_URL: 'https://cdn.example.com:8080',
+                generatePublicUri: createGeneratePublicUri('https://cdn.example.com:8080'),
             }));
             mockSend.mockResolvedValueOnce({});
             const { AWSStorageService } = require('./aws');
@@ -234,7 +247,7 @@ describe('AWSStorageService', () => {
                 S3_REGION: undefined,
                 S3_ENDPOINT: 'http://localhost:9000',
                 S3_FORCE_PATH_STYLE: true,
-                PUBLIC_URL: 'https://cdn.example.com',
+                generatePublicUri: createGeneratePublicUri('https://cdn.example.com'),
             }));
             mockSend.mockResolvedValueOnce({});
             const { AWSStorageService } = require('./aws');
@@ -253,7 +266,7 @@ describe('AWSStorageService', () => {
                 S3_REGION: 'ap-southeast-2',
                 S3_ENDPOINT: undefined,
                 S3_FORCE_PATH_STYLE: false,
-                PUBLIC_URL: 'https://cdn.example.com',
+                generatePublicUri: createGeneratePublicUri('https://cdn.example.com'),
             }));
             mockSend.mockResolvedValueOnce({});
             const { AWSStorageService } = require('./aws');
@@ -272,7 +285,7 @@ describe('AWSStorageService', () => {
                 S3_REGION: undefined,
                 S3_ENDPOINT: 'https://syd1.digitaloceanspaces.com',
                 S3_FORCE_PATH_STYLE: false,
-                PUBLIC_URL: 'not-a-valid-url',
+                generatePublicUri: createGeneratePublicUri('not-a-valid-url'),
             }));
             mockSend.mockResolvedValueOnce({});
             const { AWSStorageService } = require('./aws');
@@ -289,7 +302,7 @@ describe('AWSStorageService', () => {
                 S3_REGION: undefined,
                 S3_ENDPOINT: undefined,
                 S3_FORCE_PATH_STYLE: false,
-                PUBLIC_URL: undefined,
+                generatePublicUri: createGeneratePublicUri(undefined),
             }));
 
             expect(() => {
@@ -303,7 +316,7 @@ describe('AWSStorageService', () => {
                 S3_REGION: undefined,
                 S3_ENDPOINT: 'http://localhost:9000',
                 S3_FORCE_PATH_STYLE: true,
-                PUBLIC_URL: undefined,
+                generatePublicUri: createGeneratePublicUri(undefined),
             }));
 
             expect(() => {
@@ -317,7 +330,7 @@ describe('AWSStorageService', () => {
                 S3_REGION: undefined,
                 S3_ENDPOINT: 'not-a-valid-url',
                 S3_FORCE_PATH_STYLE: false,
-                PUBLIC_URL: undefined,
+                generatePublicUri: createGeneratePublicUri(undefined),
             }));
             mockSend.mockResolvedValueOnce({});
             const { AWSStorageService } = require('./aws');

--- a/src/services/storage/aws.test.ts
+++ b/src/services/storage/aws.test.ts
@@ -28,7 +28,7 @@ describe('AWSStorageService', () => {
                 S3_REGION: 'ap-southeast-2',
                 S3_ENDPOINT: undefined,
                 S3_FORCE_PATH_STYLE: false,
-                S3_PUBLIC_URL: undefined,
+                PUBLIC_URL: undefined,
             }));
         });
 
@@ -105,7 +105,7 @@ describe('AWSStorageService', () => {
                 S3_REGION: undefined,
                 S3_ENDPOINT: 'http://localhost:9000',
                 S3_FORCE_PATH_STYLE: true,
-                S3_PUBLIC_URL: undefined,
+                PUBLIC_URL: undefined,
             }));
         });
 
@@ -131,7 +131,7 @@ describe('AWSStorageService', () => {
                 S3_REGION: undefined,
                 S3_ENDPOINT: 'https://syd1.digitaloceanspaces.com',
                 S3_FORCE_PATH_STYLE: false,
-                S3_PUBLIC_URL: undefined,
+                PUBLIC_URL: undefined,
             }));
         });
 
@@ -151,13 +151,13 @@ describe('AWSStorageService', () => {
         });
     });
 
-    describe('S3_PUBLIC_URL override', () => {
-        it('should use S3_PUBLIC_URL when set, ignoring bucket in URI', async () => {
+    describe('PUBLIC_URL override', () => {
+        it('should use PUBLIC_URL when set, ignoring bucket in URI', async () => {
             jest.doMock('../../config', () => ({
                 S3_REGION: undefined,
                 S3_ENDPOINT: 'https://syd1.digitaloceanspaces.com',
                 S3_FORCE_PATH_STYLE: false,
-                S3_PUBLIC_URL: 'https://documents.labs.pyx.io',
+                PUBLIC_URL: 'https://documents.labs.pyx.io',
             }));
             mockSend.mockResolvedValueOnce({});
             const { AWSStorageService } = require('./aws');
@@ -171,12 +171,12 @@ describe('AWSStorageService', () => {
             expect(result).toEqual({ uri: 'https://documents.labs.pyx.io/test-key.json' });
         });
 
-        it('should strip trailing slash from S3_PUBLIC_URL', async () => {
+        it('should strip trailing slash from PUBLIC_URL', async () => {
             jest.doMock('../../config', () => ({
                 S3_REGION: undefined,
                 S3_ENDPOINT: 'https://syd1.digitaloceanspaces.com',
                 S3_FORCE_PATH_STYLE: false,
-                S3_PUBLIC_URL: 'https://documents.labs.pyx.io/',
+                PUBLIC_URL: 'https://documents.labs.pyx.io/',
             }));
             mockSend.mockResolvedValueOnce({});
             const { AWSStorageService } = require('./aws');
@@ -190,12 +190,12 @@ describe('AWSStorageService', () => {
             expect(result).toEqual({ uri: 'https://documents.labs.pyx.io/test-key.json' });
         });
 
-        it('should ignore path portion of S3_PUBLIC_URL (only origin is used)', async () => {
+        it('should ignore path portion of PUBLIC_URL (only origin is used)', async () => {
             jest.doMock('../../config', () => ({
                 S3_REGION: undefined,
                 S3_ENDPOINT: 'https://syd1.digitaloceanspaces.com',
                 S3_FORCE_PATH_STYLE: false,
-                S3_PUBLIC_URL: 'https://cdn.example.com/some/subpath',
+                PUBLIC_URL: 'https://cdn.example.com/some/subpath',
             }));
             mockSend.mockResolvedValueOnce({});
             const { AWSStorageService } = require('./aws');
@@ -210,12 +210,12 @@ describe('AWSStorageService', () => {
             expect(result).toEqual({ uri: 'https://cdn.example.com/test-key' });
         });
 
-        it('should preserve non-standard port in S3_PUBLIC_URL', async () => {
+        it('should preserve non-standard port in PUBLIC_URL', async () => {
             jest.doMock('../../config', () => ({
                 S3_REGION: undefined,
                 S3_ENDPOINT: 'http://localhost:9000',
                 S3_FORCE_PATH_STYLE: true,
-                S3_PUBLIC_URL: 'https://cdn.example.com:8080',
+                PUBLIC_URL: 'https://cdn.example.com:8080',
             }));
             mockSend.mockResolvedValueOnce({});
             const { AWSStorageService } = require('./aws');
@@ -234,7 +234,7 @@ describe('AWSStorageService', () => {
                 S3_REGION: undefined,
                 S3_ENDPOINT: 'http://localhost:9000',
                 S3_FORCE_PATH_STYLE: true,
-                S3_PUBLIC_URL: 'https://cdn.example.com',
+                PUBLIC_URL: 'https://cdn.example.com',
             }));
             mockSend.mockResolvedValueOnce({});
             const { AWSStorageService } = require('./aws');
@@ -253,7 +253,7 @@ describe('AWSStorageService', () => {
                 S3_REGION: 'ap-southeast-2',
                 S3_ENDPOINT: undefined,
                 S3_FORCE_PATH_STYLE: false,
-                S3_PUBLIC_URL: 'https://cdn.example.com',
+                PUBLIC_URL: 'https://cdn.example.com',
             }));
             mockSend.mockResolvedValueOnce({});
             const { AWSStorageService } = require('./aws');
@@ -267,19 +267,19 @@ describe('AWSStorageService', () => {
             expect(result).toEqual({ uri: 'https://cdn.example.com/test-key' });
         });
 
-        it('should throw an error if S3_PUBLIC_URL is not a valid URL', async () => {
+        it('should throw an error if PUBLIC_URL is not a valid URL', async () => {
             jest.doMock('../../config', () => ({
                 S3_REGION: undefined,
                 S3_ENDPOINT: 'https://syd1.digitaloceanspaces.com',
                 S3_FORCE_PATH_STYLE: false,
-                S3_PUBLIC_URL: 'not-a-valid-url',
+                PUBLIC_URL: 'not-a-valid-url',
             }));
             mockSend.mockResolvedValueOnce({});
             const { AWSStorageService } = require('./aws');
             const awsStorageService = new AWSStorageService();
             await expect(
                 awsStorageService.uploadFile('test-bucket', 'test-key', 'test-body', 'application/json'),
-            ).rejects.toThrow('Invalid S3_PUBLIC_URL format');
+            ).rejects.toThrow('Invalid PUBLIC_URL format');
         });
     });
 
@@ -289,7 +289,7 @@ describe('AWSStorageService', () => {
                 S3_REGION: undefined,
                 S3_ENDPOINT: undefined,
                 S3_FORCE_PATH_STYLE: false,
-                S3_PUBLIC_URL: undefined,
+                PUBLIC_URL: undefined,
             }));
 
             expect(() => {
@@ -303,7 +303,7 @@ describe('AWSStorageService', () => {
                 S3_REGION: undefined,
                 S3_ENDPOINT: 'http://localhost:9000',
                 S3_FORCE_PATH_STYLE: true,
-                S3_PUBLIC_URL: undefined,
+                PUBLIC_URL: undefined,
             }));
 
             expect(() => {
@@ -317,7 +317,7 @@ describe('AWSStorageService', () => {
                 S3_REGION: undefined,
                 S3_ENDPOINT: 'not-a-valid-url',
                 S3_FORCE_PATH_STYLE: false,
-                S3_PUBLIC_URL: undefined,
+                PUBLIC_URL: undefined,
             }));
             mockSend.mockResolvedValueOnce({});
             const { AWSStorageService } = require('./aws');

--- a/src/services/storage/aws.test.ts
+++ b/src/services/storage/aws.test.ts
@@ -28,6 +28,7 @@ describe('AWSStorageService', () => {
                 S3_REGION: 'ap-southeast-2',
                 S3_ENDPOINT: undefined,
                 S3_FORCE_PATH_STYLE: false,
+                S3_PUBLIC_URL: undefined,
             }));
         });
 
@@ -104,6 +105,7 @@ describe('AWSStorageService', () => {
                 S3_REGION: undefined,
                 S3_ENDPOINT: 'http://localhost:9000',
                 S3_FORCE_PATH_STYLE: true,
+                S3_PUBLIC_URL: undefined,
             }));
         });
 
@@ -129,6 +131,7 @@ describe('AWSStorageService', () => {
                 S3_REGION: undefined,
                 S3_ENDPOINT: 'https://syd1.digitaloceanspaces.com',
                 S3_FORCE_PATH_STYLE: false,
+                S3_PUBLIC_URL: undefined,
             }));
         });
 
@@ -148,12 +151,106 @@ describe('AWSStorageService', () => {
         });
     });
 
+    describe('S3_PUBLIC_URL override', () => {
+        it('should use S3_PUBLIC_URL when set, ignoring bucket in URI', async () => {
+            jest.doMock('../../config', () => ({
+                S3_REGION: undefined,
+                S3_ENDPOINT: 'https://syd1.digitaloceanspaces.com',
+                S3_FORCE_PATH_STYLE: false,
+                S3_PUBLIC_URL: 'https://documents.labs.pyx.io',
+            }));
+            mockSend.mockResolvedValueOnce({});
+            const { AWSStorageService } = require('./aws');
+            const awsStorageService = new AWSStorageService();
+            const result = await awsStorageService.uploadFile(
+                'test-bucket',
+                'test-key.json',
+                'test-body',
+                'application/json',
+            );
+            expect(result).toEqual({ uri: 'https://documents.labs.pyx.io/test-key.json' });
+        });
+
+        it('should strip trailing slash from S3_PUBLIC_URL', async () => {
+            jest.doMock('../../config', () => ({
+                S3_REGION: undefined,
+                S3_ENDPOINT: 'https://syd1.digitaloceanspaces.com',
+                S3_FORCE_PATH_STYLE: false,
+                S3_PUBLIC_URL: 'https://documents.labs.pyx.io/',
+            }));
+            mockSend.mockResolvedValueOnce({});
+            const { AWSStorageService } = require('./aws');
+            const awsStorageService = new AWSStorageService();
+            const result = await awsStorageService.uploadFile(
+                'test-bucket',
+                'test-key.json',
+                'test-body',
+                'application/json',
+            );
+            expect(result).toEqual({ uri: 'https://documents.labs.pyx.io/test-key.json' });
+        });
+
+        it('should take precedence over S3_ENDPOINT and S3_FORCE_PATH_STYLE', async () => {
+            jest.doMock('../../config', () => ({
+                S3_REGION: undefined,
+                S3_ENDPOINT: 'http://localhost:9000',
+                S3_FORCE_PATH_STYLE: true,
+                S3_PUBLIC_URL: 'https://cdn.example.com',
+            }));
+            mockSend.mockResolvedValueOnce({});
+            const { AWSStorageService } = require('./aws');
+            const awsStorageService = new AWSStorageService();
+            const result = await awsStorageService.uploadFile(
+                'test-bucket',
+                'test-key',
+                'test-body',
+                'application/json',
+            );
+            expect(result).toEqual({ uri: 'https://cdn.example.com/test-key' });
+        });
+
+        it('should take precedence over AWS S3 default URI generation', async () => {
+            jest.doMock('../../config', () => ({
+                S3_REGION: 'ap-southeast-2',
+                S3_ENDPOINT: undefined,
+                S3_FORCE_PATH_STYLE: false,
+                S3_PUBLIC_URL: 'https://cdn.example.com',
+            }));
+            mockSend.mockResolvedValueOnce({});
+            const { AWSStorageService } = require('./aws');
+            const awsStorageService = new AWSStorageService();
+            const result = await awsStorageService.uploadFile(
+                'test-bucket',
+                'test-key',
+                'test-body',
+                'application/json',
+            );
+            expect(result).toEqual({ uri: 'https://cdn.example.com/test-key' });
+        });
+
+        it('should throw an error if S3_PUBLIC_URL is not a valid URL', async () => {
+            jest.doMock('../../config', () => ({
+                S3_REGION: undefined,
+                S3_ENDPOINT: 'https://syd1.digitaloceanspaces.com',
+                S3_FORCE_PATH_STYLE: false,
+                S3_PUBLIC_URL: 'not-a-valid-url',
+            }));
+            mockSend.mockResolvedValueOnce({});
+            const { AWSStorageService } = require('./aws');
+            const awsStorageService = new AWSStorageService();
+            await expect(
+                awsStorageService.uploadFile('test-bucket', 'test-key', 'test-body', 'application/json'),
+            ).rejects.toThrow('Invalid S3_PUBLIC_URL format');
+        });
+    });
+
     describe('Configuration validation', () => {
         it('should throw an error if S3_REGION is not set for AWS S3', async () => {
             jest.doMock('../../config', () => ({
                 S3_REGION: undefined,
                 S3_ENDPOINT: undefined,
                 S3_FORCE_PATH_STYLE: false,
+                S3_PUBLIC_URL: undefined,
             }));
 
             expect(() => {
@@ -167,6 +264,7 @@ describe('AWSStorageService', () => {
                 S3_REGION: undefined,
                 S3_ENDPOINT: 'http://localhost:9000',
                 S3_FORCE_PATH_STYLE: true,
+                S3_PUBLIC_URL: undefined,
             }));
 
             expect(() => {
@@ -180,6 +278,7 @@ describe('AWSStorageService', () => {
                 S3_REGION: undefined,
                 S3_ENDPOINT: 'not-a-valid-url',
                 S3_FORCE_PATH_STYLE: false,
+                S3_PUBLIC_URL: undefined,
             }));
             mockSend.mockResolvedValueOnce({});
             const { AWSStorageService } = require('./aws');

--- a/src/services/storage/aws.ts
+++ b/src/services/storage/aws.ts
@@ -6,7 +6,7 @@ import {
     S3ClientConfig,
 } from '@aws-sdk/client-s3';
 import { IStorageService } from '.';
-import { S3_REGION, S3_ENDPOINT, S3_FORCE_PATH_STYLE, PUBLIC_URL } from '../../config';
+import { S3_REGION, S3_ENDPOINT, S3_FORCE_PATH_STYLE, generatePublicUri } from '../../config';
 
 /**
  * Creates the S3 client configuration.
@@ -35,19 +35,11 @@ const createS3ClientConfig = (): S3ClientConfig => {
 /**
  * Generates the public URI for an uploaded object.
  * This only affects the URI returned in API responses — not where files are uploaded to.
- * When PUBLIC_URL is set, it is used as the base URL instead of S3_ENDPOINT.
+ * When PUBLIC_URL is set, it takes precedence over all other URI generation strategies.
  */
 const generateUri = (bucket: string, key: string): string => {
-    if (PUBLIC_URL) {
-        let url: URL;
-        try {
-            url = new URL(PUBLIC_URL);
-        } catch {
-            throw new Error(`Invalid PUBLIC_URL format: "${PUBLIC_URL}" is not a valid URL`);
-        }
-        // CDN/custom domain — bucket routing handled externally
-        return `${url.origin}/${key}`;
-    }
+    const publicUri = generatePublicUri(key);
+    if (publicUri) return publicUri;
 
     if (S3_ENDPOINT) {
         let url: URL;

--- a/src/services/storage/aws.ts
+++ b/src/services/storage/aws.ts
@@ -6,7 +6,7 @@ import {
     S3ClientConfig,
 } from '@aws-sdk/client-s3';
 import { IStorageService } from '.';
-import { S3_REGION, S3_ENDPOINT, S3_FORCE_PATH_STYLE } from '../../config';
+import { S3_REGION, S3_ENDPOINT, S3_FORCE_PATH_STYLE, S3_PUBLIC_URL } from '../../config';
 
 /**
  * Creates the S3 client configuration.
@@ -34,8 +34,21 @@ const createS3ClientConfig = (): S3ClientConfig => {
 
 /**
  * Generates the public URI for an uploaded object.
+ * This only affects the URI returned in API responses — not where files are uploaded to.
+ * When S3_PUBLIC_URL is set, it is used as the base URL instead of S3_ENDPOINT.
  */
 const generateUri = (bucket: string, key: string): string => {
+    if (S3_PUBLIC_URL) {
+        let url: URL;
+        try {
+            url = new URL(S3_PUBLIC_URL);
+        } catch {
+            throw new Error(`Invalid S3_PUBLIC_URL format: "${S3_PUBLIC_URL}" is not a valid URL`);
+        }
+        // CDN/custom domain — bucket routing handled externally
+        return `${url.origin}/${key}`;
+    }
+
     if (S3_ENDPOINT) {
         let url: URL;
         try {

--- a/src/services/storage/aws.ts
+++ b/src/services/storage/aws.ts
@@ -6,7 +6,7 @@ import {
     S3ClientConfig,
 } from '@aws-sdk/client-s3';
 import { IStorageService } from '.';
-import { S3_REGION, S3_ENDPOINT, S3_FORCE_PATH_STYLE, S3_PUBLIC_URL } from '../../config';
+import { S3_REGION, S3_ENDPOINT, S3_FORCE_PATH_STYLE, PUBLIC_URL } from '../../config';
 
 /**
  * Creates the S3 client configuration.
@@ -35,15 +35,15 @@ const createS3ClientConfig = (): S3ClientConfig => {
 /**
  * Generates the public URI for an uploaded object.
  * This only affects the URI returned in API responses — not where files are uploaded to.
- * When S3_PUBLIC_URL is set, it is used as the base URL instead of S3_ENDPOINT.
+ * When PUBLIC_URL is set, it is used as the base URL instead of S3_ENDPOINT.
  */
 const generateUri = (bucket: string, key: string): string => {
-    if (S3_PUBLIC_URL) {
+    if (PUBLIC_URL) {
         let url: URL;
         try {
-            url = new URL(S3_PUBLIC_URL);
+            url = new URL(PUBLIC_URL);
         } catch {
-            throw new Error(`Invalid S3_PUBLIC_URL format: "${S3_PUBLIC_URL}" is not a valid URL`);
+            throw new Error(`Invalid PUBLIC_URL format: "${PUBLIC_URL}" is not a valid URL`);
         }
         // CDN/custom domain — bucket routing handled externally
         return `${url.origin}/${key}`;

--- a/src/services/storage/gcp.test.ts
+++ b/src/services/storage/gcp.test.ts
@@ -1,6 +1,10 @@
 import { Storage } from '@google-cloud/storage';
 import { GCPStorageService } from './gcp';
 
+jest.mock('../../config', () => ({
+    PUBLIC_URL: undefined,
+}));
+
 jest.mock('@google-cloud/storage', () => {
     const mockFileExists = jest.fn().mockResolvedValue([true]);
     const mockFileSave = jest.fn().mockResolvedValue([]);
@@ -67,5 +71,74 @@ describe('GCPStorageService', () => {
         expect(mockBucket).toHaveBeenCalledWith(bucketName);
         expect(mockFile).toHaveBeenCalledWith(key);
         expect(result).toBe(true);
+    });
+
+    describe('PUBLIC_URL override', () => {
+        beforeEach(() => {
+            jest.resetModules();
+            jest.clearAllMocks();
+        });
+
+        it('should use PUBLIC_URL when set, ignoring bucket in URI', async () => {
+            jest.doMock('../../config', () => ({
+                PUBLIC_URL: 'https://documents.labs.pyx.io',
+            }));
+
+            // Re-mock @google-cloud/storage after resetModules
+            const mockFileSave = jest.fn().mockResolvedValue([]);
+            jest.doMock('@google-cloud/storage', () => ({
+                Storage: jest.fn(() => ({
+                    bucket: jest.fn(() => ({
+                        file: jest.fn(() => ({ save: mockFileSave })),
+                    })),
+                })),
+            }));
+
+            const { GCPStorageService } = require('./gcp');
+            const service = new GCPStorageService();
+            const result = await service.uploadFile('test-bucket', 'test-key.json', 'test-body', 'application/json');
+            expect(result).toEqual({ uri: 'https://documents.labs.pyx.io/test-key.json' });
+        });
+
+        it('should use default GCS URI when PUBLIC_URL is not set', async () => {
+            jest.doMock('../../config', () => ({
+                PUBLIC_URL: undefined,
+            }));
+
+            const mockFileSave = jest.fn().mockResolvedValue([]);
+            jest.doMock('@google-cloud/storage', () => ({
+                Storage: jest.fn(() => ({
+                    bucket: jest.fn(() => ({
+                        file: jest.fn(() => ({ save: mockFileSave })),
+                    })),
+                })),
+            }));
+
+            const { GCPStorageService } = require('./gcp');
+            const service = new GCPStorageService();
+            const result = await service.uploadFile('test-bucket', 'test-key.json', 'test-body', 'application/json');
+            expect(result).toEqual({ uri: 'https://test-bucket.storage.googleapis.com/test-key.json' });
+        });
+
+        it('should throw an error if PUBLIC_URL is not a valid URL', async () => {
+            jest.doMock('../../config', () => ({
+                PUBLIC_URL: 'not-a-valid-url',
+            }));
+
+            const mockFileSave = jest.fn().mockResolvedValue([]);
+            jest.doMock('@google-cloud/storage', () => ({
+                Storage: jest.fn(() => ({
+                    bucket: jest.fn(() => ({
+                        file: jest.fn(() => ({ save: mockFileSave })),
+                    })),
+                })),
+            }));
+
+            const { GCPStorageService } = require('./gcp');
+            const service = new GCPStorageService();
+            await expect(
+                service.uploadFile('test-bucket', 'test-key', 'test-body', 'application/json'),
+            ).rejects.toThrow('Invalid PUBLIC_URL format');
+        });
     });
 });

--- a/src/services/storage/gcp.ts
+++ b/src/services/storage/gcp.ts
@@ -1,6 +1,6 @@
 import { Storage } from '@google-cloud/storage';
 import { IStorageService } from '.';
-import { PUBLIC_URL } from '../../config';
+import { generatePublicUri } from '../../config';
 
 /**
  * Google Cloud Storage service.
@@ -32,15 +32,8 @@ export class GCPStorageService implements IStorageService {
 
         await file.save(body, options);
 
-        if (PUBLIC_URL) {
-            let url: URL;
-            try {
-                url = new URL(PUBLIC_URL);
-            } catch {
-                throw new Error(`Invalid PUBLIC_URL format: "${PUBLIC_URL}" is not a valid URL`);
-            }
-            return { uri: `${url.origin}/${key}` };
-        }
+        const publicUri = generatePublicUri(key);
+        if (publicUri) return { uri: publicUri };
 
         return { uri: `https://${bucket}.storage.googleapis.com/${key}` };
     }

--- a/src/services/storage/gcp.ts
+++ b/src/services/storage/gcp.ts
@@ -1,5 +1,6 @@
 import { Storage } from '@google-cloud/storage';
 import { IStorageService } from '.';
+import { PUBLIC_URL } from '../../config';
 
 /**
  * Google Cloud Storage service.
@@ -30,6 +31,16 @@ export class GCPStorageService implements IStorageService {
         };
 
         await file.save(body, options);
+
+        if (PUBLIC_URL) {
+            let url: URL;
+            try {
+                url = new URL(PUBLIC_URL);
+            } catch {
+                throw new Error(`Invalid PUBLIC_URL format: "${PUBLIC_URL}" is not a valid URL`);
+            }
+            return { uri: `${url.origin}/${key}` };
+        }
 
         return { uri: `https://${bucket}.storage.googleapis.com/${key}` };
     }


### PR DESCRIPTION
This PR adds an optional `PUBLIC_URL` environment variable that overrides the URI returned to clients after file uploads. When set, API responses use `PUBLIC_URL` as the base URL instead of constructing one from the storage provider's default endpoint. Uploads and all other storage operations are unaffected; only the URI in API responses changes.

This is storage-agnostic, applying to both `aws` and `gcp` storage types. Local storage is unaffected (development only). The primary use case is placing a CDN or custom domain in front of an S3-compatible provider like DigitalOcean Spaces.

## Test plan
- [x] Existing URI generation unchanged when `PUBLIC_URL` is not set (AWS S3, path-style, virtual-hosted, GCP)
- [x] `PUBLIC_URL` used as base URL, bucket name excluded from path
- [x] Trailing slash stripped
- [x] Path components discarded (only origin used)
- [x] Non-standard ports preserved
- [x] `PUBLIC_URL` takes precedence over `S3_ENDPOINT`, `S3_FORCE_PATH_STYLE`, and AWS/GCP defaults
- [x] Invalid `PUBLIC_URL` throws descriptive error on first upload
- [x] Full unit test suite passes (157 tests), `aws.ts` at 100% coverage