### PR TITLE
feat(api): add DELETE endpoint for removing stored resources

### DIFF
--- a/e2e/delete.s3.e2e.test.ts
+++ b/e2e/delete.s3.e2e.test.ts
@@ -1,0 +1,154 @@
+import request from 'supertest';
+import { v4 as uuidv4 } from 'uuid';
+import { APP_BASE_URL, API_KEY, API_VERSION } from './helpers';
+
+jest.setTimeout(30000);
+
+const testDocument = {
+    '@context': ['https://www.w3.org/2018/credentials/v1'],
+    type: ['VerifiableCredential'],
+    issuer: 'did:example:123',
+    credentialSubject: {
+        id: 'did:example:456',
+        name: 'Test Subject',
+    },
+};
+
+// Minimal valid PNG (1x1 transparent pixel)
+const MINIMAL_PNG = Buffer.from(
+    '89504e470d0a1a0a0000000d49484452000000010000000108060000001f15c489' +
+        '0000000a49444154789c626000000002000198e195280000000049454e44ae426082',
+    'hex',
+);
+
+describe('Delete API - S3 E2E Tests', () => {
+    describe(`DELETE /api/${API_VERSION}/:bucket/:id`, () => {
+        describe('Authentication', () => {
+            it('should return 401 when API key is missing', async () => {
+                const response = await request(APP_BASE_URL)
+                    .delete(`/api/${API_VERSION}/documents/${uuidv4()}`)
+                    .expect(401);
+
+                expect(response.body.message).toContain('API key is required');
+            });
+
+            it('should return 401 when API key is invalid', async () => {
+                const response = await request(APP_BASE_URL)
+                    .delete(`/api/${API_VERSION}/documents/${uuidv4()}`)
+                    .set('X-API-Key', 'wrong-api-key')
+                    .expect(401);
+
+                expect(response.body.message).toContain('Invalid API key');
+            });
+        });
+
+        describe('Validation', () => {
+            it('should return 400 when bucket is not in available list', async () => {
+                const response = await request(APP_BASE_URL)
+                    .delete(`/api/${API_VERSION}/nonexistent/${uuidv4()}`)
+                    .set('X-API-Key', API_KEY)
+                    .expect(400);
+
+                expect(response.body.message).toContain('Invalid bucket');
+            });
+
+            it('should return 400 when id is not a valid UUID', async () => {
+                const response = await request(APP_BASE_URL)
+                    .delete(`/api/${API_VERSION}/documents/not-a-uuid`)
+                    .set('X-API-Key', API_KEY)
+                    .expect(400);
+
+                expect(response.body.message).toContain('Invalid id');
+            });
+        });
+
+        describe('Delete operations', () => {
+            it('should return 204 when deleting a public JSON document', async () => {
+                const docId = uuidv4();
+
+                // Store first
+                await request(APP_BASE_URL)
+                    .post(`/api/${API_VERSION}/public`)
+                    .set('X-API-Key', API_KEY)
+                    .send({ bucket: 'documents', id: docId, data: testDocument })
+                    .expect(201);
+
+                // Delete
+                await request(APP_BASE_URL)
+                    .delete(`/api/${API_VERSION}/documents/${docId}`)
+                    .set('X-API-Key', API_KEY)
+                    .expect(204);
+            });
+
+            it('should return 204 when deleting a public binary file', async () => {
+                const fileId = uuidv4();
+
+                // Store first
+                await request(APP_BASE_URL)
+                    .post(`/api/${API_VERSION}/public`)
+                    .set('X-API-Key', API_KEY)
+                    .attach('file', MINIMAL_PNG, { filename: 'test.png', contentType: 'image/png' })
+                    .field('bucket', 'files')
+                    .field('id', fileId)
+                    .expect(201);
+
+                // Delete
+                await request(APP_BASE_URL)
+                    .delete(`/api/${API_VERSION}/files/${fileId}`)
+                    .set('X-API-Key', API_KEY)
+                    .expect(204);
+            });
+
+            it('should return 204 when deleting a private document', async () => {
+                const docId = uuidv4();
+
+                // Store first
+                await request(APP_BASE_URL)
+                    .post(`/api/${API_VERSION}/private`)
+                    .set('X-API-Key', API_KEY)
+                    .send({ bucket: 'documents', id: docId, data: testDocument })
+                    .expect(201);
+
+                // Delete
+                await request(APP_BASE_URL)
+                    .delete(`/api/${API_VERSION}/documents/${docId}`)
+                    .set('X-API-Key', API_KEY)
+                    .expect(204);
+            });
+
+            it('should return 404 when resource does not exist', async () => {
+                const response = await request(APP_BASE_URL)
+                    .delete(`/api/${API_VERSION}/documents/${uuidv4()}`)
+                    .set('X-API-Key', API_KEY)
+                    .expect(404);
+
+                expect(response.body.message).toContain('not found');
+            });
+
+            it('should return 404 when deleting the same resource twice', async () => {
+                const docId = uuidv4();
+
+                // Store
+                await request(APP_BASE_URL)
+                    .post(`/api/${API_VERSION}/public`)
+                    .set('X-API-Key', API_KEY)
+                    .send({ bucket: 'documents', id: docId, data: testDocument })
+                    .expect(201);
+
+                // First delete succeeds
+                await request(APP_BASE_URL)
+                    .delete(`/api/${API_VERSION}/documents/${docId}`)
+                    .set('X-API-Key', API_KEY)
+                    .expect(204);
+
+                // Second delete returns 404
+                const response = await request(APP_BASE_URL)
+                    .delete(`/api/${API_VERSION}/documents/${docId}`)
+                    .set('X-API-Key', API_KEY)
+                    .expect(404);
+
+                expect(response.body.message).toContain('not found');
+            });
+        });
+    });
+});

--- a/src/errors.ts
+++ b/src/errors.ts
@@ -20,6 +20,12 @@ export class UnauthorizedError extends ApiError {
     }
 }
 
+export class NotFoundError extends ApiError {
+    constructor(message: string) {
+        super(message, 404);
+    }
+}
+
 export class ConflictError extends ApiError {
     constructor(message: string) {
         super(message, 409);

--- a/src/routes/delete/controller.test.ts
+++ b/src/routes/delete/controller.test.ts
@@ -1,0 +1,87 @@
+import { getMockReq, getMockRes } from '@jest-mock/express';
+import { deleteResource } from './controller';
+import { DeleteService } from './service';
+import { BadRequestError, NotFoundError } from '../../errors';
+
+const { res: mockRes, next: mockNext, clearMockRes } = getMockRes();
+
+jest.mock('../../config', () => ({
+    AVAILABLE_BUCKETS: ['my-bucket'],
+    STORAGE_TYPE: 'gcp',
+}));
+
+jest.mock('../../services/storage/gcp', () => ({
+    GCPStorageService: jest.fn().mockImplementation(() => ({
+        uploadFile: jest.fn(),
+        objectExists: jest.fn(),
+        listObjectsByPrefix: jest.fn().mockResolvedValue([]),
+        deleteFile: jest.fn(),
+    })),
+}));
+
+describe('DeleteController', () => {
+    beforeEach(() => {
+        clearMockRes();
+        jest.clearAllMocks();
+    });
+
+    it('should return 204 when delete succeeds', async () => {
+        jest.spyOn(DeleteService.prototype, 'deleteDocument').mockResolvedValue(undefined);
+
+        const mockReq = getMockReq({
+            params: { bucket: 'my-bucket', id: '123e4567-e89b-12d3-a456-426614174000' },
+        });
+
+        await deleteResource(mockReq, mockRes, mockNext);
+
+        expect(mockRes.status).toHaveBeenCalledWith(204);
+        expect(mockRes.send).toHaveBeenCalled();
+    });
+
+    it('should return 400 for invalid bucket', async () => {
+        jest.spyOn(DeleteService.prototype, 'deleteDocument').mockRejectedValue(new BadRequestError('Invalid bucket'));
+
+        const mockReq = getMockReq({
+            params: { bucket: 'invalid-bucket', id: '123e4567-e89b-12d3-a456-426614174000' },
+        });
+
+        await deleteResource(mockReq, mockRes, mockNext);
+
+        expect(mockRes.status).toHaveBeenCalledWith(400);
+        expect(mockRes.json).toHaveBeenCalledWith({
+            message: expect.stringContaining('Invalid bucket'),
+        });
+    });
+
+    it('should return 404 when resource is not found', async () => {
+        jest.spyOn(DeleteService.prototype, 'deleteDocument').mockRejectedValue(
+            new NotFoundError('Resource not found'),
+        );
+
+        const mockReq = getMockReq({
+            params: { bucket: 'my-bucket', id: '123e4567-e89b-12d3-a456-426614174000' },
+        });
+
+        await deleteResource(mockReq, mockRes, mockNext);
+
+        expect(mockRes.status).toHaveBeenCalledWith(404);
+        expect(mockRes.json).toHaveBeenCalledWith({
+            message: expect.stringContaining('Resource not found'),
+        });
+    });
+
+    it('should return 500 for unexpected errors', async () => {
+        jest.spyOn(DeleteService.prototype, 'deleteDocument').mockRejectedValue(new Error('Something went wrong'));
+
+        const mockReq = getMockReq({
+            params: { bucket: 'my-bucket', id: '123e4567-e89b-12d3-a456-426614174000' },
+        });
+
+        await deleteResource(mockReq, mockRes, mockNext);
+
+        expect(mockRes.status).toHaveBeenCalledWith(500);
+        expect(mockRes.json).toHaveBeenCalledWith({
+            message: 'An unexpected error occurred while deleting the resource.',
+        });
+    });
+});

--- a/src/routes/delete/controller.ts
+++ b/src/routes/delete/controller.ts
@@ -1,0 +1,27 @@
+import { RequestHandler } from 'express';
+import { initialiseStorageService, IStorageService } from '../../services';
+import { DeleteService } from './service';
+import { ApiError } from '../../errors';
+
+export const deleteResource: RequestHandler = async (req, res) => {
+    try {
+        const deleteService = new DeleteService();
+        const storageService: IStorageService = initialiseStorageService();
+
+        const { bucket, id } = req.params;
+
+        await deleteService.deleteDocument(storageService, bucket, id);
+
+        res.status(204).send();
+    } catch (err: any) {
+        console.error('[DeleteController.deleteResource] An error occurred while deleting the resource.', err);
+
+        if (err instanceof ApiError) {
+            return res.status(err.statusCode).json({ message: err.message });
+        }
+
+        res.status(500).json({
+            message: 'An unexpected error occurred while deleting the resource.',
+        });
+    }
+};

--- a/src/routes/delete/index.ts
+++ b/src/routes/delete/index.ts
@@ -1,0 +1,7 @@
+import { Router } from 'express';
+import { deleteResource } from './controller';
+import { authenticateRequest } from '../../middleware/authentication';
+
+export const deleteRouter = Router();
+
+deleteRouter.delete('/:bucket/:id', authenticateRequest, deleteResource as any);

--- a/src/routes/delete/service.test.ts
+++ b/src/routes/delete/service.test.ts
@@ -1,0 +1,94 @@
+import { IStorageService } from '../../services';
+import { DeleteService } from './service';
+import { BadRequestError, NotFoundError, ApplicationError } from '../../errors';
+
+jest.mock('../../config', () => ({
+    AVAILABLE_BUCKETS: ['my-bucket'],
+}));
+
+describe('DeleteService', () => {
+    let service: DeleteService;
+    let mockStorageService: jest.Mocked<IStorageService>;
+
+    beforeEach(() => {
+        jest.clearAllMocks();
+
+        service = new DeleteService();
+
+        mockStorageService = {
+            uploadFile: jest.fn(),
+            objectExists: jest.fn(),
+            listObjectsByPrefix: jest.fn().mockResolvedValue(['123e4567-e89b-12d3-a456-426614174000.json']),
+            deleteFile: jest.fn().mockResolvedValue(undefined),
+        };
+    });
+
+    const validBucket = 'my-bucket';
+    const validId = '123e4567-e89b-12d3-a456-426614174000';
+
+    it('should successfully delete a document', async () => {
+        await service.deleteDocument(mockStorageService, validBucket, validId);
+
+        expect(mockStorageService.listObjectsByPrefix).toHaveBeenCalledWith(validBucket, validId);
+        expect(mockStorageService.deleteFile).toHaveBeenCalledWith(
+            validBucket,
+            '123e4567-e89b-12d3-a456-426614174000.json',
+        );
+    });
+
+    it('should throw BadRequestError when bucket is not in AVAILABLE_BUCKETS', async () => {
+        await expect(service.deleteDocument(mockStorageService, 'invalid-bucket', validId)).rejects.toThrow(
+            BadRequestError,
+        );
+        await expect(service.deleteDocument(mockStorageService, 'invalid-bucket', validId)).rejects.toThrow(
+            'Invalid bucket',
+        );
+    });
+
+    it('should throw BadRequestError when id is not a valid UUID', async () => {
+        await expect(service.deleteDocument(mockStorageService, validBucket, 'not-a-uuid')).rejects.toThrow(
+            BadRequestError,
+        );
+        await expect(service.deleteDocument(mockStorageService, validBucket, 'not-a-uuid')).rejects.toThrow(
+            'Invalid id',
+        );
+    });
+
+    it('should throw NotFoundError when no objects match the id', async () => {
+        mockStorageService.listObjectsByPrefix.mockResolvedValue([]);
+
+        await expect(service.deleteDocument(mockStorageService, validBucket, validId)).rejects.toThrow(NotFoundError);
+        mockStorageService.listObjectsByPrefix.mockResolvedValue([]);
+        await expect(service.deleteDocument(mockStorageService, validBucket, validId)).rejects.toThrow('not found');
+    });
+
+    it('should delete the first matched object when multiple exist', async () => {
+        mockStorageService.listObjectsByPrefix.mockResolvedValue([
+            '123e4567-e89b-12d3-a456-426614174000.json',
+            '123e4567-e89b-12d3-a456-426614174000.png',
+        ]);
+
+        await service.deleteDocument(mockStorageService, validBucket, validId);
+
+        expect(mockStorageService.deleteFile).toHaveBeenCalledWith(
+            validBucket,
+            '123e4567-e89b-12d3-a456-426614174000.json',
+        );
+    });
+
+    it('should throw ApplicationError when listObjectsByPrefix fails', async () => {
+        mockStorageService.listObjectsByPrefix.mockRejectedValue(new Error('Storage connection failed'));
+
+        await expect(service.deleteDocument(mockStorageService, validBucket, validId)).rejects.toThrow(
+            ApplicationError,
+        );
+    });
+
+    it('should throw ApplicationError when deleteFile fails', async () => {
+        mockStorageService.deleteFile.mockRejectedValue(new Error('Delete failed'));
+
+        await expect(service.deleteDocument(mockStorageService, validBucket, validId)).rejects.toThrow(
+            ApplicationError,
+        );
+    });
+});

--- a/src/routes/delete/service.test.ts
+++ b/src/routes/delete/service.test.ts
@@ -62,18 +62,15 @@ describe('DeleteService', () => {
         await expect(service.deleteDocument(mockStorageService, validBucket, validId)).rejects.toThrow('not found');
     });
 
-    it('should delete the first matched object when multiple exist', async () => {
-        mockStorageService.listObjectsByPrefix.mockResolvedValue([
-            '123e4567-e89b-12d3-a456-426614174000.json',
-            '123e4567-e89b-12d3-a456-426614174000.png',
-        ]);
+    it('should delete all matched objects when multiple exist', async () => {
+        const keys = ['123e4567-e89b-12d3-a456-426614174000.json', '123e4567-e89b-12d3-a456-426614174000.png'];
+        mockStorageService.listObjectsByPrefix.mockResolvedValue(keys);
 
         await service.deleteDocument(mockStorageService, validBucket, validId);
 
-        expect(mockStorageService.deleteFile).toHaveBeenCalledWith(
-            validBucket,
-            '123e4567-e89b-12d3-a456-426614174000.json',
-        );
+        expect(mockStorageService.deleteFile).toHaveBeenCalledTimes(2);
+        expect(mockStorageService.deleteFile).toHaveBeenCalledWith(validBucket, keys[0]);
+        expect(mockStorageService.deleteFile).toHaveBeenCalledWith(validBucket, keys[1]);
     });
 
     it('should throw ApplicationError when listObjectsByPrefix fails', async () => {

--- a/src/routes/delete/service.ts
+++ b/src/routes/delete/service.ts
@@ -1,0 +1,36 @@
+import { IStorageService } from '../../services';
+import { ApiError, ApplicationError, BadRequestError, NotFoundError } from '../../errors';
+import { AVAILABLE_BUCKETS } from '../../config';
+import { isValidUUID } from '../../utils';
+
+export class DeleteService {
+    public async deleteDocument(storageService: IStorageService, bucket: string, id: string): Promise<void> {
+        try {
+            if (!AVAILABLE_BUCKETS.includes(bucket)) {
+                throw new BadRequestError(
+                    `Invalid bucket. Must be one of the following buckets: ${AVAILABLE_BUCKETS.join(', ')}`,
+                );
+            }
+
+            if (!isValidUUID(id)) {
+                throw new BadRequestError(`Invalid id ${id}. Please provide a valid UUID.`);
+            }
+
+            const matchingKeys = await storageService.listObjectsByPrefix(bucket, id);
+
+            if (matchingKeys.length === 0) {
+                throw new NotFoundError(`Resource with id ${id} not found in bucket ${bucket}.`);
+            }
+
+            await storageService.deleteFile(bucket, matchingKeys[0]);
+        } catch (err: any) {
+            console.error('[DeleteService.deleteDocument] An error occurred while deleting the resource.', err);
+
+            if (err instanceof ApiError) {
+                throw err;
+            }
+
+            throw new ApplicationError('An unexpected error occurred while deleting the resource.');
+        }
+    }
+}

--- a/src/routes/delete/service.ts
+++ b/src/routes/delete/service.ts
@@ -22,7 +22,7 @@ export class DeleteService {
                 throw new NotFoundError(`Resource with id ${id} not found in bucket ${bucket}.`);
             }
 
-            await storageService.deleteFile(bucket, matchingKeys[0]);
+            await Promise.all(matchingKeys.map((key) => storageService.deleteFile(bucket, key)));
         } catch (err: any) {
             console.error('[DeleteService.deleteDocument] An error occurred while deleting the resource.', err);
 

--- a/src/routes/index.ts
+++ b/src/routes/index.ts
@@ -2,10 +2,12 @@ import express, { Router } from 'express';
 import path from 'path';
 import { publicRouter } from './public';
 import { privateRouter } from './private';
+import { deleteRouter } from './delete';
 import { LOCAL_DIRECTORY, __dirname } from '../config';
 
 export const router = Router();
 
 router.use('/public', publicRouter);
 router.use('/private', privateRouter);
+router.use('/', deleteRouter);
 router.use(express.static(path.join(__dirname, LOCAL_DIRECTORY)));

--- a/src/routes/private/service.test.ts
+++ b/src/routes/private/service.test.ts
@@ -10,6 +10,8 @@ jest.mock('../../config', () => ({
 const storageService = {
     uploadFile: jest.fn().mockResolvedValue({ uri: 'mock-uri' }),
     objectExists: jest.fn().mockResolvedValue(false),
+    listObjectsByPrefix: jest.fn().mockResolvedValue([]),
+    deleteFile: jest.fn().mockResolvedValue(undefined),
 };
 
 const cryptographyService = {

--- a/src/routes/public/service.test.ts
+++ b/src/routes/public/service.test.ts
@@ -26,6 +26,8 @@ describe('PublicService', () => {
         mockStorageService = {
             uploadFile: jest.fn().mockResolvedValue({ uri: 'https://storage.example.com/my-bucket/test-id.json' }),
             objectExists: jest.fn().mockResolvedValue(false),
+            listObjectsByPrefix: jest.fn().mockResolvedValue([]),
+            deleteFile: jest.fn().mockResolvedValue(undefined),
         };
 
         mockCryptoService = {

--- a/src/services/storage/gcp.ts
+++ b/src/services/storage/gcp.ts
@@ -50,4 +50,28 @@ export class GCPStorageService implements IStorageService {
         const [exists] = await file.exists();
         return exists;
     }
+
+    /**
+     * Lists objects in a Google Cloud Storage bucket filtered by a prefix.
+     * @param bucket The bucket name to list objects from.
+     * @param prefix The prefix to filter objects by.
+     * @returns A promise that resolves to an array of object names matching the prefix.
+     */
+    async listObjectsByPrefix(bucket: string, prefix: string): Promise<string[]> {
+        const bucketInstance = this.storage.bucket(bucket);
+        const [files] = await bucketInstance.getFiles({ prefix });
+        return files.map((file) => file.name);
+    }
+
+    /**
+     * Deletes a file from Google Cloud Storage.
+     * @param bucket The bucket name containing the file.
+     * @param key The key or path of the file to delete.
+     * @returns A promise that resolves when the file is deleted.
+     */
+    async deleteFile(bucket: string, key: string): Promise<void> {
+        const bucketInstance = this.storage.bucket(bucket);
+        const file = bucketInstance.file(key);
+        await file.delete();
+    }
 }

--- a/src/services/storage/index.ts
+++ b/src/services/storage/index.ts
@@ -20,4 +20,20 @@ export interface IStorageService {
      * @returns A promise that resolves to a boolean indicating whether the object exists.
      */
     objectExists(bucket: string, key: string): Promise<boolean>;
+
+    /**
+     * Lists object keys in a bucket that match a given prefix.
+     * @param bucket The bucket or container name to search.
+     * @param prefix The prefix to filter keys by.
+     * @returns A promise that resolves to an array of matching object keys.
+     */
+    listObjectsByPrefix(bucket: string, prefix: string): Promise<string[]>;
+
+    /**
+     * Deletes a file from the storage service.
+     * @param bucket The bucket or container name containing the file.
+     * @param key The key or path of the file to delete.
+     * @returns A promise that resolves when the file has been deleted.
+     */
+    deleteFile(bucket: string, key: string): Promise<void>;
 }

--- a/src/services/storage/local.ts
+++ b/src/services/storage/local.ts
@@ -45,4 +45,34 @@ export class LocalStorageService implements IStorageService {
             });
         });
     }
+
+    /**
+     * Lists objects in a bucket whose filenames start with the given prefix.
+     * @param bucket The bucket name (directory).
+     * @param prefix The prefix to filter filenames by.
+     * @returns A promise that resolves to an array of matching filenames.
+     */
+    async listObjectsByPrefix(bucket: string, prefix: string): Promise<string[]> {
+        const dirPath = path.join(__dirname, LOCAL_DIRECTORY, bucket);
+        try {
+            const files = await fs.promises.readdir(dirPath);
+            return files.filter((file: string) => file.startsWith(prefix));
+        } catch (err: any) {
+            if (err.code === 'ENOENT') {
+                return [];
+            }
+            throw err;
+        }
+    }
+
+    /**
+     * Deletes a file from the local file system.
+     * @param bucket The bucket name (directory).
+     * @param key The key or path of the file to delete.
+     * @returns A promise that resolves when the file is deleted.
+     */
+    async deleteFile(bucket: string, key: string): Promise<void> {
+        const filePath = path.join(__dirname, LOCAL_DIRECTORY, bucket, key);
+        await fs.promises.unlink(filePath);
+    }
 }

--- a/src/swagger/components/responses.json
+++ b/src/swagger/components/responses.json
@@ -49,6 +49,22 @@
                     }
                 }
             },
+            "404": {
+                "description": "The requested resource was not found.",
+                "content": {
+                    "application/json": {
+                        "schema": {
+                            "type": "object",
+                            "properties": {
+                                "message": {
+                                    "type": "string",
+                                    "example": "Resource with id 123e4567-e89b-12d3-a456-426614174000 not found in bucket documents."
+                                }
+                            }
+                        }
+                    }
+                }
+            },
             "500": {
                 "description": "An unexpected error occurred while storing the document.",
                 "content": {

--- a/src/swagger/paths.json
+++ b/src/swagger/paths.json
@@ -164,6 +164,52 @@
                     }
                 }
             }
+        },
+        "/{bucket}/{id}": {
+            "delete": {
+                "summary": "Delete a stored resource.",
+                "description": "Delete a previously stored resource (public or encrypted) by bucket and ID. Uses prefix matching to locate the resource regardless of file extension.",
+                "parameters": [
+                    {
+                        "name": "bucket",
+                        "in": "path",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        },
+                        "description": "The bucket containing the resource.",
+                        "example": "documents"
+                    },
+                    {
+                        "name": "id",
+                        "in": "path",
+                        "required": true,
+                        "schema": {
+                            "type": "string",
+                            "format": "uuid"
+                        },
+                        "description": "The UUID of the resource to delete.",
+                        "example": "123e4567-e89b-12d3-a456-426614174000"
+                    }
+                ],
+                "responses": {
+                    "204": {
+                        "description": "Resource deleted successfully. No content returned."
+                    },
+                    "400": {
+                        "$ref": "./components/responses.json#/components/responses/400"
+                    },
+                    "401": {
+                        "$ref": "./components/responses.json#/components/responses/401"
+                    },
+                    "404": {
+                        "$ref": "./components/responses.json#/components/responses/404"
+                    },
+                    "500": {
+                        "$ref": "./components/responses.json#/components/responses/500"
+                    }
+                }
+            }
         }
     }
 }

--- a/src/swagger/swagger.json
+++ b/src/swagger/swagger.json
@@ -174,6 +174,52 @@
           }
         }
       }
+    },
+    "/{bucket}/{id}": {
+      "delete": {
+        "summary": "Delete a stored resource.",
+        "description": "Delete a previously stored resource (public or encrypted) by bucket and ID. Uses prefix matching to locate the resource regardless of file extension.",
+        "parameters": [
+          {
+            "name": "bucket",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "description": "The bucket containing the resource.",
+            "example": "documents"
+          },
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            },
+            "description": "The UUID of the resource to delete.",
+            "example": "123e4567-e89b-12d3-a456-426614174000"
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "Resource deleted successfully. No content returned."
+          },
+          "400": {
+            "$ref": "#/components/responses/400"
+          },
+          "401": {
+            "$ref": "#/components/responses/401"
+          },
+          "404": {
+            "$ref": "#/components/responses/404"
+          },
+          "500": {
+            "$ref": "#/components/responses/500"
+          }
+        }
+      }
     }
   },
   "components": {
@@ -314,6 +360,22 @@
                 "message": {
                   "type": "string",
                   "example": "API key is required. Please provide a valid API key in the X-API-Key header."
+                }
+              }
+            }
+          }
+        }
+      },
+      "404": {
+        "description": "The requested resource was not found.",
+        "content": {
+          "application/json": {
+            "schema": {
+              "type": "object",
+              "properties": {
+                "message": {
+                  "type": "string",
+                  "example": "Resource with id 123e4567-e89b-12d3-a456-426614174000 not found in bucket documents."
                 }
               }
             }


### PR DESCRIPTION
## Summary

This PR adds a unified `DELETE /:bucket/:id` endpoint that allows callers to remove previously stored resources (public or encrypted) by bucket and ID. The endpoint uses prefix-based object listing to resolve file extensions, so callers only need the resource UUID.

- Extends `IStorageService` with `listObjectsByPrefix` and `deleteFile` across all three storage providers (AWS S3, GCP, Local)
- Returns 204 No Content on success, 404 if the resource does not exist, 400 for invalid bucket/UUID
- Includes Swagger/OpenAPI documentation and E2E tests against MinIO

## Test plan
- [x] Unit tests for DeleteService (7 tests: success, bad bucket, bad UUID, not found, multiple matches, storage failures)
- [x] Unit tests for delete controller (4 tests: 204, 400, 404, 500 responses)
- [x] Unit tests for all three storage providers' new methods (13 tests total)
- [x] E2E tests against MinIO (8 tests: auth, validation, delete public/private/binary, not found, double delete)
- [x] Existing test suites unaffected (207 tests passing)