### PR TITLE
feat(api)!: switch URL path version segment from full SemVer to major-only (v4)

### DIFF
--- a/README.md
+++ b/README.md
@@ -268,25 +268,25 @@ Examples:
 
 ```bash
 # Store public JSON data (no encryption)
-curl -X POST http://localhost:3333/api/3.0.0/public \
+curl -X POST http://localhost:3333/api/v4/public \
 -H "Content-Type: application/json" \
 -H "X-API-Key: your-api-key-here" \
 -d '{"bucket": "documents", "data": {"field1": "value1"}}'
 
 # Store private JSON data (encrypted)
-curl -X POST http://localhost:3333/api/3.0.0/private \
+curl -X POST http://localhost:3333/api/v4/private \
 -H "Content-Type: application/json" \
 -H "X-API-Key: your-api-key-here" \
 -d '{"bucket": "documents", "data": {"field1": "value1"}}'
 
 # Upload a public binary file
-curl -X POST http://localhost:3333/api/3.0.0/public \
+curl -X POST http://localhost:3333/api/v4/public \
 -H "X-API-Key: your-api-key-here" \
 -F "bucket=files" \
 -F "file=@/path/to/image.png"
 
 # Delete a stored resource
-curl -X DELETE http://localhost:3333/api/3.0.0/documents/123e4567-e89b-12d3-a456-426614174000 \
+curl -X DELETE http://localhost:3333/api/v4/documents/123e4567-e89b-12d3-a456-426614174000 \
 -H "X-API-Key: your-api-key-here"
 ```
 

--- a/RELEASE_MANAGEMENT_GUIDE.md
+++ b/RELEASE_MANAGEMENT_GUIDE.md
@@ -99,7 +99,6 @@ The version.json file serves as a central metadata file to define the versioning
 // version.json
 {
   "version": "1.0.0",
-  "apiVersion": "1.0.0",
   "docVersion": "1.0.0",
   "dependencies": {
     // Example dependency service
@@ -114,7 +113,6 @@ The version.json file serves as a central metadata file to define the versioning
 ### Key Fields
 
 - version: The version of the current service. Must align with the Git tag.
-- apiVersion: The API version exposed by the service, the field is optional.
 - docVersion: The version of the documentation.
 - dependencies: A list of dependent services with their repositories and compatible version list, the field is optional.
 - repoUrl: URL of the repository for the dependent service.

--- a/RELEASE_MANAGEMENT_GUIDE.md
+++ b/RELEASE_MANAGEMENT_GUIDE.md
@@ -99,6 +99,7 @@ The version.json file serves as a central metadata file to define the versioning
 // version.json
 {
   "version": "1.0.0",
+  "apiVersion": "1.0",
   "docVersion": "1.0.0",
   "dependencies": {
     // Example dependency service
@@ -113,6 +114,7 @@ The version.json file serves as a central metadata file to define the versioning
 ### Key Fields
 
 - version: The version of the current service. Must align with the Git tag.
+- apiVersion: The API contract version as `MAJOR.MINOR`. Kept in lockstep with the URL path segment (`/api/v<MAJOR>`, sourced from the routes directory `src/routes/v<MAJOR>/`); MINOR bumps document backwards-compatible additions to the API surface and do not change the URL.
 - docVersion: The version of the documentation.
 - dependencies: A list of dependent services with their repositories and compatible version list, the field is optional.
 - repoUrl: URL of the repository for the dependent service.

--- a/docs/adrs/001-multibase-digest-replaces-hex-hash.md
+++ b/docs/adrs/001-multibase-digest-replaces-hex-hash.md
@@ -1,0 +1,57 @@
+# ADR: digestMultibase replaces hex hash as the content-integrity field
+
+- **Date:** 2026-05-19
+- **Status:** accepted
+
+## Context
+
+Through 3.2.x, every store response carried a hex SHA-256 `hash` field as the content-integrity value. The hex form carries digest bytes only; the algorithm (SHA-256) and the encoding (lowercase hex) have to be communicated out of band. A consumer verifying integrity must already know, by contract, both of those facts. If we ever change algorithm, every consumer needs a coordinated update.
+
+The wider content-integrity ecosystem has converged on self-describing digest formats. A multibase-encoded multihash carries the algorithm identifier (as a multihash code), the digest length, and the digest bytes, all wrapped in a multibase string-encoding that identifies the base used. A consumer reading a multibase-encoded multihash value can decode it and verify content integrity without any out-of-band metadata.
+
+In parallel with this work, a shared utility primitive shipped in `@uncefact/untp-utils@0.1.0` (see tests-untp ADR 003): `MultibaseDigest.fromData(...)`. The primitive standardises the algorithm choice (sha2-256), the multibase variant (base58btc), and the encoded shape, so multiple downstream products can adopt the same digest convention without each making its own algorithm or encoding choices.
+
+A decision is needed: continue emitting hex SHA-256, emit both forms transitionally, or replace the hex form with a multibase-encoded multihash sourced from the shared utility.
+
+## Decision
+
+Replace the hex `hash` field with `digestMultibase` (a multibase-encoded multihash). Digest computation goes through `@uncefact/untp-utils` `MultibaseDigest.fromData(...)`, so the algorithm and multibase choices are owned by the shared utility and not duplicated per consumer.
+
+The hex `hash` field is removed in the 4.0.0 release. There is no overlap release that returns both fields.
+
+## Consequences
+
+**What becomes easier:**
+
+- Consumers can verify the digest from the value alone. The algorithm identifier and the encoding are recoverable from the `digestMultibase` value, so no out-of-band metadata is required to interpret it.
+- The storage service aligns with how content integrity is typically expressed in the wider ecosystem. Consumers that already speak that vocabulary need no special-case handling for our digests.
+- Future algorithm or encoding evolution happens once in `@uncefact/untp-utils`, not in every product that emits a digest.
+
+**What becomes more difficult:**
+
+- 4.0.0 is a breaking change for any consumer that reads `response.hash`. Consumers must be updated in lockstep with the URL path change (ADR 002).
+- Downstream systems that still require a hex SHA-256 must decode the multibase digest themselves (documented in the 4.0.0 migration guide). This is mechanical but adds a small amount of consumer-side code.
+- The storage service now has a runtime dependency on `@uncefact/untp-utils`. Version churn in that package can ripple in.
+
+## Alternatives Considered
+
+### Keep emitting hex `hash` only
+
+Rejected. The hex form needs out-of-band metadata to interpret, ties consumers to a fixed algorithm, and is increasingly out of step with how content integrity is expressed across the ecosystems the storage service is meant to interoperate with.
+
+### Emit both `hash` and `digestMultibase` for a transitional release
+
+Rejected. Two fields encoding the same digest forces every consumer to choose, splits the consumer population during the transition, and extends rather than shortens the deprecation cycle. A clean major-version cut is simpler to communicate and migrate against, and the migration mechanics are well understood (clients flip a single field reference).
+
+### Compute the digest inside the storage service rather than via `@uncefact/untp-utils`
+
+Rejected. The same primitive is needed across multiple downstream products. Duplicating the algorithm and encoding choices in each consumer creates drift risk; centralising in `@uncefact/untp-utils` keeps the choices coherent across products without each having to track the others.
+
+## References
+
+- #111 (PR replacing hex hash with `digestMultibase`)
+- tests-untp ADR 003 (`@uncefact/untp-utils` package)
+- `@uncefact/untp-utils@0.1.0`
+- [Multihash specification](https://github.com/multiformats/multihash)
+- [Multibase specification](https://github.com/multiformats/multibase)
+- `documentation/docs/migration-guides/migrating-to-4.md`

--- a/docs/adrs/002-url-path-major-only-version-segment.md
+++ b/docs/adrs/002-url-path-major-only-version-segment.md
@@ -1,0 +1,68 @@
+# ADR: URL path version segment is major-only, sourced from the routes directory
+
+- **Date:** 2026-05-19
+- **Status:** accepted
+
+## Context
+
+Through 3.2.x, the storage service embedded the full SemVer of the API in every URL path: `/api/3.1.0/public`, `/api/3.2.1/:bucket/:id`, and so on. The runtime read the value from an `apiVersion` field in `version.json` at startup and used it as the URL prefix.
+
+This shape inverts what SemVer is for. Minor and patch bumps are non-breaking by definition; the API contract is, by definition, unchanged for clients. But embedding the full SemVer in the path means a minor or patch bump produces new URLs, which forces every client to update on bumps that do not affect them. Either the contract guarantee is meaningless or the URL is structured wrong; the URL is structured wrong.
+
+A second observation: deriving the URL prefix from a runtime config value (the `apiVersion` field) made the routing layer dependent on a file read at startup. The actual source of truth for "what API major does this service expose" lives in the routes themselves; the config value duplicates that information and creates room for the two to drift.
+
+The decision needs to cover the URL shape, where the URL prefix is sourced from, and what (if anything) keeps `apiVersion` in `version.json` doing.
+
+## Decision
+
+Three coupled changes:
+
+1. **URL path version segment becomes `v<MAJOR>`.** `/api/3.1.0/public` becomes `/api/v4/public`. The path changes only when the API contract changes (i.e. on a MAJOR bump).
+2. **The URL prefix is sourced from the routes directory.** The router that mounts `/api/v4` imports from `src/routes/v4/`. There is no runtime read of a config value to determine which version segment appears in the URL; the directory layout is the source of truth, and route imports are static.
+3. **`apiVersion` in `version.json` switches from full SemVer to `MAJOR.MINOR`.** It documents the API contract version as published to consumers. The MAJOR of `apiVersion` is kept in lockstep with the URL path's `v<MAJOR>` (human responsibility, not enforced at runtime). The MINOR bumps when backwards-compatible additions land on the API surface and do not change the URL. The value is read once at startup and bound to the Swagger `info.version` field so the published OpenAPI document carries the same contract version that `version.json` records.
+
+The result: the URL is determined by where the routes live, and `apiVersion` is a small documentation surface that propagates the contract version through to the published OpenAPI document. The two are intentionally separate concerns kept aligned by a small, visible rule.
+
+## Consequences
+
+**What becomes easier:**
+
+- Clients only update URLs when the contract genuinely breaks. Minor and patch bumps are invisible at the URL level.
+- The routes directory is the canonical answer to "what API version does this service expose." Adding a new major version means adding a directory and a router; deleting an old one means deleting the directory. There is no parallel config to update.
+- Swagger `info.version` is sourced from `version.json`, so consumers reading the OpenAPI document see the same version string the repository records.
+
+**What becomes more difficult:**
+
+- This is a breaking change. Existing URIs that point at `/api/3.x.x/...` (notably those persisted by clients of the local-storage adapter) return 404 against a 4.0.0 deployment. Mitigation is documented in the 4.0.0 migration guide; there is no server-side redirect.
+- The lockstep between the URL's `v<MAJOR>` and `apiVersion`'s MAJOR is a human responsibility. Nothing at runtime enforces it. A reviewer must catch the case where someone bumps `apiVersion` to `5.0` without also adding `src/routes/v5/`, or vice versa.
+- Rolling a new major now requires creating a new routes directory rather than bumping a config string. This is a small extra step but it is mechanical, and it is the cost of making the directory the source of truth.
+
+## Alternatives Considered
+
+### Keep full SemVer in the URL
+
+Rejected. Defeats the purpose of SemVer. Minor and patch bumps are non-breaking by definition, so URLs containing the full version force clients to update on bumps that should be invisible to them.
+
+### Major-only URL, but source the value from `version.json` (or an env var) at runtime
+
+Rejected. Once the URL is major-only, the routes directory is the natural source of truth: the major appears in the directory name (`src/routes/v<MAJOR>/`) and in the route registration. Introducing a runtime read of a config string adds an indirection that can drift from the routes layout and offers no benefit; the URL is determined by where the code lives, not by a string in a file.
+
+### Dynamically discover routes from the filesystem at startup
+
+Rejected. Static imports keep startup behaviour predictable, keep the dependency graph visible to tooling and bundlers, and avoid coupling the routing layer to filesystem shape. Filesystem-driven discovery also makes it harder to reason about what is mounted where without running the service.
+
+### Remove `apiVersion` from `version.json` entirely; inline `"4.0"` in `src/app.ts` for Swagger
+
+Considered, then rejected after review. The runtime cost of reading `version.json` once at startup is negligible, and keeping `apiVersion` in `version.json` gives a single, file-based source of truth for the contract version that flows through to the published OpenAPI document. Inlining the value would create a second place that has to be updated when MINOR moves, and the file is the more discoverable home (it's already where consumers and CI tooling look for version information).
+
+### Carry both URL shapes during a transition (`/api/3.x.x/...` and `/api/v4/...`)
+
+Rejected. The point of the major-only URL is that path changes signal contract changes; introducing the same surface under two paths for a transition window blurs the signal, doubles the routing surface to maintain, and lengthens the deprecation cycle. The migration is mechanical (clients change the prefix), so a clean cut is the simpler path.
+
+## References
+
+- #115 (PR introducing the URL path change)
+- `src/routes/v4/`
+- `src/config.ts` (`getApiVersion`, `API_VERSION`)
+- `src/app.ts` (Swagger `info.version` binding)
+- `documentation/docs/migration-guides/migrating-to-4.md`

--- a/docs/adrs/README.md
+++ b/docs/adrs/README.md
@@ -1,0 +1,60 @@
+# Architectural Decision Records (ADRs)
+
+## What are ADRs?
+
+Architectural Decision Records capture significant structural and architectural decisions made during the development of this project. Each ADR describes a decision, its context, the alternatives considered, and the consequences of the choice made.
+
+This project uses ADRs to maintain a transparent, searchable history of _why_ the codebase is shaped the way it is, not just _what_ was built.
+
+## Where they live
+
+All ADRs are stored in `docs/adrs/` at the repository root.
+
+## Naming convention
+
+ADR files follow this pattern:
+
+```
+NNN-short-slug.md
+```
+
+Where `NNN` is a zero-padded sequence number assigned at creation time (next free number; do not reuse retired numbers). For example: `003-some-decision.md`.
+
+Use lowercase, hyphen-separated slugs. Keep them short but descriptive.
+
+## Status lifecycle
+
+Every ADR has a status field that follows this lifecycle:
+
+```
+proposed -> accepted -> superseded / deprecated
+```
+
+| Status         | Meaning                                             |
+| -------------- | --------------------------------------------------- |
+| **proposed**   | Under discussion; not yet agreed upon               |
+| **accepted**   | Agreed and in effect                                |
+| **superseded** | Replaced by a newer ADR (link to the replacement)   |
+| **deprecated** | No longer relevant; withdrawn without a replacement |
+
+## When to create an ADR
+
+Create an ADR for **structural and architectural decisions only**:
+
+- New patterns or conventions that affect the codebase structure
+- Technology choices (frameworks, libraries, infrastructure)
+- Service boundaries and integration approaches
+- Data model design decisions
+- Deployment topology changes
+- Authentication/authorisation strategy changes
+
+**Do not** create an ADR for:
+
+- Bug fixes
+- Minor code style or formatting choices
+- Routine dependency updates
+- Individual feature implementations (unless they introduce a new pattern)
+
+## How to create one
+
+Copy `TEMPLATE.md` from this directory, rename it following the naming convention above, and fill in each section.

--- a/docs/adrs/TEMPLATE.md
+++ b/docs/adrs/TEMPLATE.md
@@ -1,0 +1,25 @@
+# ADR: [Title]
+
+- **Date:** YYYY-MM-DD
+- **Status:** proposed | accepted | superseded | deprecated
+- **Superseded by:** [ADR link, if applicable]
+
+## Context
+
+What is the issue that we're seeing that is motivating this decision or change?
+
+## Decision
+
+What is the change that we're proposing and/or doing?
+
+## Consequences
+
+What becomes easier or more difficult to do because of this change?
+
+## Alternatives Considered
+
+What other approaches were evaluated? Why were they rejected?
+
+## References
+
+Links to specs, PRs, issues, external resources, or related ADRs.

--- a/documentation/docs/contributing/release-process/index.md
+++ b/documentation/docs/contributing/release-process/index.md
@@ -17,15 +17,18 @@ This page describes the branch structure, versioning scheme, and step-by-step re
 
 The project maintains version information in three files:
 
-- **`version.json`** -- Contains `version` and `docVersion` fields:
+- **`version.json`** -- Contains `version`, `apiVersion`, and `docVersion` fields:
 
 ```json
 {
     "version": "MAJOR.MINOR.PATCH",
+    "apiVersion": "MAJOR.MINOR",
     "docVersion": "MAJOR.MINOR.PATCH",
     "dependencies": {}
 }
 ```
+
+The `apiVersion` documents the API contract version as `MAJOR.MINOR`. It is kept in lockstep with the URL path segment (`/api/v<MAJOR>`, derived from the routes directory under `src/routes/v<MAJOR>/`): the MAJOR of `apiVersion` always matches the MAJOR in the URL. MINOR bumps document backwards-compatible additions to the API surface and do not change the URL.
 
 - **`package.json`** -- The `version` field must match `version.json`.
 - **`documentation/package.json`** -- The `version` field must match the `docVersion` in `version.json`.

--- a/documentation/docs/contributing/release-process/index.md
+++ b/documentation/docs/contributing/release-process/index.md
@@ -17,12 +17,11 @@ This page describes the branch structure, versioning scheme, and step-by-step re
 
 The project maintains version information in three files:
 
-- **`version.json`** -- Contains `version`, `apiVersion`, and `docVersion` fields:
+- **`version.json`** -- Contains `version` and `docVersion` fields:
 
 ```json
 {
     "version": "MAJOR.MINOR.PATCH",
-    "apiVersion": "MAJOR.MINOR.PATCH",
     "docVersion": "MAJOR.MINOR.PATCH",
     "dependencies": {}
 }
@@ -52,7 +51,7 @@ git checkout -b release/X.Y.Z
 ```
 
 2. **Update version files.** Set the new version number in:
-    - `version.json` (`version`, `apiVersion` if the API has changed, `docVersion`)
+    - `version.json` (`version`, `docVersion`)
     - `package.json` (`version`)
     - `documentation/package.json` (`version`, if `docVersion` changed)
 

--- a/documentation/docs/developer-guide/api-reference/index.md
+++ b/documentation/docs/developer-guide/api-reference/index.md
@@ -17,7 +17,7 @@ X-API-Key: your-secure-api-key-here
 
 ## Store Public Data
 
-- **Endpoint**: `POST /api/3.0.0/public`
+- **Endpoint**: `POST /api/v4/public`
 - **Authentication**: Required (`X-API-Key` header)
 - **Content Types**: `application/json` or `multipart/form-data`
 
@@ -26,7 +26,7 @@ Stores data or files without encryption. Returns a URI where the content can be 
 ### JSON Upload
 
 ```bash
-curl -X POST http://localhost:3333/api/3.0.0/public \
+curl -X POST http://localhost:3333/api/v4/public \
 -H "Content-Type: application/json" \
 -H "X-API-Key: your-secure-api-key-here" \
 -d '{
@@ -41,7 +41,7 @@ Example response:
 
 ```json
 {
-    "uri": "http://localhost:3333/api/3.0.0/documents/2ad789c7-e513-4523-a826-ab59e1c423cd.json",
+    "uri": "http://localhost:3333/api/v4/documents/2ad789c7-e513-4523-a826-ab59e1c423cd.json",
     "digestMultibase": "zQmcnsmRVVuPbmPwesYza9zXSbn5GJMQU4x9RnFDAZdcKCD"
 }
 ```
@@ -49,7 +49,7 @@ Example response:
 ### Binary File Upload
 
 ```bash
-curl -X POST http://localhost:3333/api/3.0.0/public \
+curl -X POST http://localhost:3333/api/v4/public \
 -H "X-API-Key: your-secure-api-key-here" \
 -F "file=@/path/to/image.png" \
 -F "bucket=files"
@@ -59,7 +59,7 @@ Example response:
 
 ```json
 {
-    "uri": "http://localhost:3333/api/3.0.0/files/123e4567-e89b-12d3-a456-426614174000.png",
+    "uri": "http://localhost:3333/api/v4/files/123e4567-e89b-12d3-a456-426614174000.png",
     "digestMultibase": "zQmcnsmRVVuPbmPwesYza9zXSbn5GJMQU4x9RnFDAZdcKCD"
 }
 ```
@@ -91,7 +91,7 @@ Example response:
 
 ## Store Private Data
 
-- **Endpoint**: `POST /api/3.0.0/private`
+- **Endpoint**: `POST /api/v4/private`
 - **Authentication**: Required (`X-API-Key` header)
 - **Content Types**: `application/json` or `multipart/form-data`
 
@@ -100,7 +100,7 @@ Automatically encrypts and stores data or files. Returns a URI, a digestMultibas
 ### JSON Upload
 
 ```bash
-curl -X POST http://localhost:3333/api/3.0.0/private \
+curl -X POST http://localhost:3333/api/v4/private \
 -H "Content-Type: application/json" \
 -H "X-API-Key: your-secure-api-key-here" \
 -d '{
@@ -115,7 +115,7 @@ Example response:
 
 ```json
 {
-    "uri": "http://localhost:3333/api/3.0.0/documents/e8b32169-582c-421a-a03f-5d1a7ac62d51.json",
+    "uri": "http://localhost:3333/api/v4/documents/e8b32169-582c-421a-a03f-5d1a7ac62d51.json",
     "digestMultibase": "zQmcnsmRVVuPbmPwesYza9zXSbn5GJMQU4x9RnFDAZdcKCD",
     "decryptionKey": "f3bee3dc18343aaab66d28fd70a03015d2ddbd5fd3b9ad38fff332c09014598d"
 }
@@ -124,7 +124,7 @@ Example response:
 ### Binary File Upload
 
 ```bash
-curl -X POST http://localhost:3333/api/3.0.0/private \
+curl -X POST http://localhost:3333/api/v4/private \
 -H "X-API-Key: your-secure-api-key-here" \
 -F "file=@/path/to/image.png" \
 -F "bucket=files"
@@ -134,7 +134,7 @@ Example response:
 
 ```json
 {
-    "uri": "http://localhost:3333/api/3.0.0/files/123e4567-e89b-12d3-a456-426614174000.json",
+    "uri": "http://localhost:3333/api/v4/files/123e4567-e89b-12d3-a456-426614174000.json",
     "digestMultibase": "zQmcnsmRVVuPbmPwesYza9zXSbn5GJMQU4x9RnFDAZdcKCD",
     "decryptionKey": "a1bc2de3f4567890abcdef1234567890abcdef1234567890abcdef1234567890"
 }
@@ -168,13 +168,13 @@ Example response:
 
 ## Delete a Resource
 
-- **Endpoint**: `DELETE /api/3.0.0/:bucket/:id`
+- **Endpoint**: `DELETE /api/v4/:bucket/:id`
 - **Authentication**: Required (`X-API-Key` header)
 
 Deletes a previously stored resource (public or encrypted) by bucket and ID. Uses prefix matching to locate the resource regardless of file extension. If multiple objects share the same ID prefix, all are deleted.
 
 ```bash
-curl -X DELETE http://localhost:3333/api/3.0.0/documents/2ad789c7-e513-4523-a826-ab59e1c423cd \
+curl -X DELETE http://localhost:3333/api/v4/documents/2ad789c7-e513-4523-a826-ab59e1c423cd \
 -H "X-API-Key: your-secure-api-key-here"
 ```
 

--- a/documentation/docs/migration-guides/migrating-to-3.md
+++ b/documentation/docs/migration-guides/migrating-to-3.md
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 1
+sidebar_position: 2
 title: Migrating to 3.0.0
 ---
 

--- a/documentation/docs/migration-guides/migrating-to-4.md
+++ b/documentation/docs/migration-guides/migrating-to-4.md
@@ -1,0 +1,127 @@
+---
+sidebar_position: 1
+title: Migrating to 4.0.0
+---
+
+This guide is for users upgrading from version 3.x to 4.0.0. Two breaking changes land together in the 4.0.0 release: the URL path version segment changes shape, and the legacy hex `hash` field is removed from store responses in favour of `digestMultibase`. Work through each section to ensure a smooth transition.
+
+## API URL Path Version Segment
+
+The version segment in the URL path changes from full SemVer (`/api/3.x.x/`) to major-only with a `v` prefix (`/api/v4/`).
+
+### Why this changed
+
+Embedding the full SemVer in the URL inverts what SemVer is for. Minor and patch bumps are non-breaking by definition, so URLs containing the full version forced clients to update on changes that should not have affected them. Major-only paths preserve the original intent: the path changes only when the contract changes.
+
+### Before (3.x)
+
+| Endpoint                            | Method | Path                           |
+| ----------------------------------- | ------ | ------------------------------ |
+| Store public data (JSON or binary)  | POST   | `/api/3.x.x/public`            |
+| Store private data (JSON or binary) | POST   | `/api/3.x.x/private`           |
+| Delete a stored resource            | DELETE | `/api/3.x.x/:bucket/:id`       |
+| Retrieve a local-storage file       | GET    | `/api/3.x.x/:bucket/:filename` |
+
+### After (4.0.0)
+
+| Endpoint                            | Method | Path                        |
+| ----------------------------------- | ------ | --------------------------- |
+| Store public data (JSON or binary)  | POST   | `/api/v4/public`            |
+| Store private data (JSON or binary) | POST   | `/api/v4/private`           |
+| Delete a stored resource            | DELETE | `/api/v4/:bucket/:id`       |
+| Retrieve a local-storage file       | GET    | `/api/v4/:bucket/:filename` |
+
+### Migration steps
+
+Replace the version segment in every URL your client calls:
+
+```diff
+- POST /api/3.1.0/public
++ POST /api/v4/public
+
+- POST /api/3.1.0/private
++ POST /api/v4/private
+
+- DELETE /api/3.1.0/documents/2ad789c7-e513-4523-a826-ab59e1c423cd
++ DELETE /api/v4/documents/2ad789c7-e513-4523-a826-ab59e1c423cd
+```
+
+:::warning
+Requests to the old SemVer paths return `404 Not Found`. There is no server-side redirect; the legacy paths are gone, not aliased.
+:::
+
+### Stored URIs
+
+If your client persists the `uri` returned from previous store calls, those URIs continue to reference the old path shape. Existing URIs that point at local storage (`http://.../api/3.x.x/<bucket>/<filename>`) will return 404 against a 4.0.0 deployment. Either re-store the data to receive a fresh URI, or rewrite the stored URIs in place to use `/api/v4/`.
+
+URIs returned by S3 or GCS adapters point directly at the object store, not at the storage service, so they are unaffected by the path change.
+
+## Response Field: `hash` Removed, `digestMultibase` Stays
+
+The legacy hex SHA-256 `hash` field is removed from every store response. The `digestMultibase` field (a multibase-encoded multihash) is the sole content-integrity field returned.
+
+### Why this changed
+
+The hex `hash` and `digestMultibase` fields encoded the same digest in two different ways. Carrying both pushed consumers to choose, and the hex form has none of the self-describing properties of the multibase-encoded multihash form: the algorithm and the encoding are recoverable from the `digestMultibase` value alone, without out-of-band metadata.
+
+The multibase-encoded multihash form is also what W3C Verifiable Credentials and the UNTP credentials vocabulary use for content integrity, so dropping the hex form aligns the storage service with the wider ecosystem.
+
+### Before (3.2.x)
+
+```json
+{
+    "uri": "https://example.com/api/3.1.0/documents/2ad789c7-e513-4523-a826-ab59e1c423cd.json",
+    "hash": "d6bb7b579925baa4fe1cec41152b6577003e6a9fde6850321e36ad4ac9b3f30a",
+    "digestMultibase": "zQmcnsmRVVuPbmPwesYza9zXSbn5GJMQU4x9RnFDAZdcKCD"
+}
+```
+
+### After (4.0.0)
+
+```json
+{
+    "uri": "https://example.com/api/v4/documents/2ad789c7-e513-4523-a826-ab59e1c423cd.json",
+    "digestMultibase": "zQmcnsmRVVuPbmPwesYza9zXSbn5GJMQU4x9RnFDAZdcKCD"
+}
+```
+
+### Migration steps
+
+Update every consumer that reads `response.hash` to read `response.digestMultibase` instead.
+
+```diff
+- const integrity = response.hash;
++ const integrity = response.digestMultibase;
+```
+
+If you specifically need a hex SHA-256 for legacy interop, decode the multibase digest in your code (base58btc-decode the value, strip the two-byte multihash prefix `0x12 0x20` for sha2-256, and hex-encode the remaining 32 bytes). The W3C VC ecosystem reads `digestMultibase` directly, so this transformation is only needed if a downstream system you do not control still requires hex.
+
+:::warning
+The `digestMultibase` value is a multibase-encoded multihash, not a raw hash. Treat it as a self-describing string and use a multibase / multihash library to decode it. Stripping the leading `z` does not give you a hex hash.
+:::
+
+## Version File Internals
+
+The `apiVersion` field has been removed from `version.json`. The path segment now lives in the URL routing (`src/routes/v4/`) and no longer needs a separate field.
+
+```diff
+// version.json
+ {
+     "version": "4.0.0",
+-    "apiVersion": "3.1.0",
+     "docVersion": "4.0.0",
+     "dependencies": {}
+ }
+```
+
+If you have CI or tooling that reads `apiVersion` from `version.json`, update it to read the URL segment from the routing layer or drop the dependency altogether. The new convention is: the URL path version is `v<MAJOR>`, derived from the latest route directory under `src/routes/`.
+
+## Docker images
+
+Pull the 4.0.0 image:
+
+```bash
+docker pull ghcr.io/uncefact/project-storage-service:4.0.0
+```
+
+The previous `3.x.x` images continue to serve the old URL shape and the old response field. Switching deployments to 4.0.0 is a coordinated client-side update.

--- a/documentation/docs/migration-guides/migrating-to-4.md
+++ b/documentation/docs/migration-guides/migrating-to-4.md
@@ -56,23 +56,22 @@ If your client persists the `uri` returned from previous store calls, those URIs
 
 URIs returned by S3 or GCS adapters point directly at the object store, not at the storage service, so they are unaffected by the path change.
 
-## Response Field: `hash` Removed, `digestMultibase` Stays
+## Response Field: `hash` Replaced By `digestMultibase`
 
-The legacy hex SHA-256 `hash` field is removed from every store response. The `digestMultibase` field (a multibase-encoded multihash) is the sole content-integrity field returned.
+The legacy hex SHA-256 `hash` field is removed from every store response and replaced by `digestMultibase`, a multibase-encoded multihash.
 
 ### Why this changed
 
-The hex `hash` and `digestMultibase` fields encoded the same digest in two different ways. Carrying both pushed consumers to choose, and the hex form has none of the self-describing properties of the multibase-encoded multihash form: the algorithm and the encoding are recoverable from the `digestMultibase` value alone, without out-of-band metadata.
+The hex `hash` form carries the digest bytes only; the algorithm and the encoding have to be communicated out of band. The multibase-encoded multihash form is self-describing: the algorithm and the encoding are recoverable from the value alone, so consumers can verify content integrity without separate metadata.
 
-The multibase-encoded multihash form is also what W3C Verifiable Credentials and the UNTP credentials vocabulary use for content integrity, so dropping the hex form aligns the storage service with the wider ecosystem.
+The multibase-encoded multihash form has broad adoption across the content-integrity ecosystem, so the switch aligns the storage service with how content integrity is typically expressed.
 
 ### Before (3.2.x)
 
 ```json
 {
     "uri": "https://example.com/api/3.1.0/documents/2ad789c7-e513-4523-a826-ab59e1c423cd.json",
-    "hash": "d6bb7b579925baa4fe1cec41152b6577003e6a9fde6850321e36ad4ac9b3f30a",
-    "digestMultibase": "zQmcnsmRVVuPbmPwesYza9zXSbn5GJMQU4x9RnFDAZdcKCD"
+    "hash": "d6bb7b579925baa4fe1cec41152b6577003e6a9fde6850321e36ad4ac9b3f30a"
 }
 ```
 
@@ -94,7 +93,7 @@ Update every consumer that reads `response.hash` to read `response.digestMultiba
 + const integrity = response.digestMultibase;
 ```
 
-If you specifically need a hex SHA-256 for legacy interop, decode the multibase digest in your code (base58btc-decode the value, strip the two-byte multihash prefix `0x12 0x20` for sha2-256, and hex-encode the remaining 32 bytes). The W3C VC ecosystem reads `digestMultibase` directly, so this transformation is only needed if a downstream system you do not control still requires hex.
+If a downstream system you do not control still requires a hex SHA-256, decode the multibase digest in your code (base58btc-decode the value, strip the two-byte multihash prefix `0x12 0x20` for sha2-256, and hex-encode the remaining 32 bytes).
 
 :::warning
 The `digestMultibase` value is a multibase-encoded multihash, not a raw hash. Treat it as a self-describing string and use a multibase / multihash library to decode it. Stripping the leading `z` does not give you a hex hash.
@@ -102,19 +101,20 @@ The `digestMultibase` value is a multibase-encoded multihash, not a raw hash. Tr
 
 ## Version File Internals
 
-The `apiVersion` field has been removed from `version.json`. The path segment now lives in the URL routing (`src/routes/v4/`) and no longer needs a separate field.
+The `apiVersion` field in `version.json` switches from full SemVer to `MAJOR.MINOR` to mirror the contract shape. The MAJOR stays in lockstep with the URL path segment (`v<MAJOR>` under `src/routes/`); MINOR documents backwards-compatible additions to the API surface.
 
 ```diff
 // version.json
  {
      "version": "4.0.0",
 -    "apiVersion": "3.1.0",
++    "apiVersion": "4.0",
      "docVersion": "4.0.0",
      "dependencies": {}
  }
 ```
 
-If you have CI or tooling that reads `apiVersion` from `version.json`, update it to read the URL segment from the routing layer or drop the dependency altogether. The new convention is: the URL path version is `v<MAJOR>`, derived from the latest route directory under `src/routes/`.
+CI or tooling that parses `apiVersion` as full SemVer needs to be updated to expect a `MAJOR.MINOR` value.
 
 ## Docker images
 

--- a/e2e/delete.s3.e2e.test.ts
+++ b/e2e/delete.s3.e2e.test.ts
@@ -1,6 +1,6 @@
 import request from 'supertest';
 import { v4 as uuidv4 } from 'uuid';
-import { APP_BASE_URL, API_KEY, API_VERSION } from './helpers';
+import { APP_BASE_URL, API_KEY } from './helpers';
 
 jest.setTimeout(30000);
 
@@ -22,19 +22,17 @@ const MINIMAL_PNG = Buffer.from(
 );
 
 describe('Delete API - S3 E2E Tests', () => {
-    describe(`DELETE /api/${API_VERSION}/:bucket/:id`, () => {
+    describe(`DELETE /api/v4/:bucket/:id`, () => {
         describe('Authentication', () => {
             it('should return 401 when API key is missing', async () => {
-                const response = await request(APP_BASE_URL)
-                    .delete(`/api/${API_VERSION}/documents/${uuidv4()}`)
-                    .expect(401);
+                const response = await request(APP_BASE_URL).delete(`/api/v4/documents/${uuidv4()}`).expect(401);
 
                 expect(response.body.message).toContain('API key is required');
             });
 
             it('should return 401 when API key is invalid', async () => {
                 const response = await request(APP_BASE_URL)
-                    .delete(`/api/${API_VERSION}/documents/${uuidv4()}`)
+                    .delete(`/api/v4/documents/${uuidv4()}`)
                     .set('X-API-Key', 'wrong-api-key')
                     .expect(401);
 
@@ -45,7 +43,7 @@ describe('Delete API - S3 E2E Tests', () => {
         describe('Validation', () => {
             it('should return 400 when bucket is not in available list', async () => {
                 const response = await request(APP_BASE_URL)
-                    .delete(`/api/${API_VERSION}/nonexistent/${uuidv4()}`)
+                    .delete(`/api/v4/nonexistent/${uuidv4()}`)
                     .set('X-API-Key', API_KEY)
                     .expect(400);
 
@@ -54,7 +52,7 @@ describe('Delete API - S3 E2E Tests', () => {
 
             it('should return 400 when id is not a valid UUID', async () => {
                 const response = await request(APP_BASE_URL)
-                    .delete(`/api/${API_VERSION}/documents/not-a-uuid`)
+                    .delete(`/api/v4/documents/not-a-uuid`)
                     .set('X-API-Key', API_KEY)
                     .expect(400);
 
@@ -68,16 +66,13 @@ describe('Delete API - S3 E2E Tests', () => {
 
                 // Store first
                 await request(APP_BASE_URL)
-                    .post(`/api/${API_VERSION}/public`)
+                    .post(`/api/v4/public`)
                     .set('X-API-Key', API_KEY)
                     .send({ bucket: 'documents', id: docId, data: testDocument })
                     .expect(201);
 
                 // Delete
-                await request(APP_BASE_URL)
-                    .delete(`/api/${API_VERSION}/documents/${docId}`)
-                    .set('X-API-Key', API_KEY)
-                    .expect(204);
+                await request(APP_BASE_URL).delete(`/api/v4/documents/${docId}`).set('X-API-Key', API_KEY).expect(204);
             });
 
             it('should return 204 when deleting a public binary file', async () => {
@@ -85,7 +80,7 @@ describe('Delete API - S3 E2E Tests', () => {
 
                 // Store first
                 await request(APP_BASE_URL)
-                    .post(`/api/${API_VERSION}/public`)
+                    .post(`/api/v4/public`)
                     .set('X-API-Key', API_KEY)
                     .attach('file', MINIMAL_PNG, { filename: 'test.png', contentType: 'image/png' })
                     .field('bucket', 'files')
@@ -93,10 +88,7 @@ describe('Delete API - S3 E2E Tests', () => {
                     .expect(201);
 
                 // Delete
-                await request(APP_BASE_URL)
-                    .delete(`/api/${API_VERSION}/files/${fileId}`)
-                    .set('X-API-Key', API_KEY)
-                    .expect(204);
+                await request(APP_BASE_URL).delete(`/api/v4/files/${fileId}`).set('X-API-Key', API_KEY).expect(204);
             });
 
             it('should return 204 when deleting a private document', async () => {
@@ -104,21 +96,18 @@ describe('Delete API - S3 E2E Tests', () => {
 
                 // Store first
                 await request(APP_BASE_URL)
-                    .post(`/api/${API_VERSION}/private`)
+                    .post(`/api/v4/private`)
                     .set('X-API-Key', API_KEY)
                     .send({ bucket: 'documents', id: docId, data: testDocument })
                     .expect(201);
 
                 // Delete
-                await request(APP_BASE_URL)
-                    .delete(`/api/${API_VERSION}/documents/${docId}`)
-                    .set('X-API-Key', API_KEY)
-                    .expect(204);
+                await request(APP_BASE_URL).delete(`/api/v4/documents/${docId}`).set('X-API-Key', API_KEY).expect(204);
             });
 
             it('should return 404 when resource does not exist', async () => {
                 const response = await request(APP_BASE_URL)
-                    .delete(`/api/${API_VERSION}/documents/${uuidv4()}`)
+                    .delete(`/api/v4/documents/${uuidv4()}`)
                     .set('X-API-Key', API_KEY)
                     .expect(404);
 
@@ -130,20 +119,17 @@ describe('Delete API - S3 E2E Tests', () => {
 
                 // Store
                 await request(APP_BASE_URL)
-                    .post(`/api/${API_VERSION}/public`)
+                    .post(`/api/v4/public`)
                     .set('X-API-Key', API_KEY)
                     .send({ bucket: 'documents', id: docId, data: testDocument })
                     .expect(201);
 
                 // First delete succeeds
-                await request(APP_BASE_URL)
-                    .delete(`/api/${API_VERSION}/documents/${docId}`)
-                    .set('X-API-Key', API_KEY)
-                    .expect(204);
+                await request(APP_BASE_URL).delete(`/api/v4/documents/${docId}`).set('X-API-Key', API_KEY).expect(204);
 
                 // Second delete returns 404
                 const response = await request(APP_BASE_URL)
-                    .delete(`/api/${API_VERSION}/documents/${docId}`)
+                    .delete(`/api/v4/documents/${docId}`)
                     .set('X-API-Key', API_KEY)
                     .expect(404);
 

--- a/e2e/helpers.ts
+++ b/e2e/helpers.ts
@@ -1,7 +1,5 @@
 import crypto from 'crypto';
 
-import { apiVersion as API_VERSION } from '../version.json';
-
 /** Base URL for the containerised app */
 export const APP_BASE_URL = 'http://localhost:3334';
 
@@ -13,9 +11,6 @@ const MINIO_HOST_ENDPOINT = 'http://localhost:9010';
 
 /** API key matching the hardcoded value in docker-compose.e2e.yml */
 export const API_KEY = 'test-api-key-e2e';
-
-/** API version from version.json, used for URL paths */
-export { API_VERSION };
 
 /**
  * Rewrites a URI returned by the API to be resolvable from the host machine.

--- a/e2e/private.s3.e2e.test.ts
+++ b/e2e/private.s3.e2e.test.ts
@@ -3,7 +3,6 @@ import { v4 as uuidv4 } from 'uuid';
 import {
     APP_BASE_URL,
     API_KEY,
-    API_VERSION,
     resolveUri,
     computeDigestMultibase,
     decryptEnvelope,
@@ -41,11 +40,11 @@ const MINIMAL_PDF = Buffer.from(
 const OVERSIZED_FILE = Buffer.alloc(10485761, 0x00);
 
 describe('Private API - S3 E2E Tests', () => {
-    describe(`POST /api/${API_VERSION}/private (JSON)`, () => {
+    describe(`POST /api/v4/private (JSON)`, () => {
         describe('Authentication', () => {
             it('should return 401 when API key is missing', async () => {
                 const response = await request(APP_BASE_URL)
-                    .post(`/api/${API_VERSION}/private`)
+                    .post(`/api/v4/private`)
                     .send({ bucket: 'documents', data: testDocument })
                     .expect(401);
 
@@ -54,7 +53,7 @@ describe('Private API - S3 E2E Tests', () => {
 
             it('should return 401 when API key is invalid', async () => {
                 const response = await request(APP_BASE_URL)
-                    .post(`/api/${API_VERSION}/private`)
+                    .post(`/api/v4/private`)
                     .set('X-API-Key', 'invalid-key')
                     .send({ bucket: 'documents', data: testDocument })
                     .expect(401);
@@ -66,7 +65,7 @@ describe('Private API - S3 E2E Tests', () => {
         describe('Validation', () => {
             it('should return 400 when bucket is missing', async () => {
                 const response = await request(APP_BASE_URL)
-                    .post(`/api/${API_VERSION}/private`)
+                    .post(`/api/v4/private`)
                     .set('X-API-Key', API_KEY)
                     .send({ data: testDocument })
                     .expect(400);
@@ -76,7 +75,7 @@ describe('Private API - S3 E2E Tests', () => {
 
             it('should return 400 when bucket is not in available list', async () => {
                 const response = await request(APP_BASE_URL)
-                    .post(`/api/${API_VERSION}/private`)
+                    .post(`/api/v4/private`)
                     .set('X-API-Key', API_KEY)
                     .send({ bucket: 'nonexistent-bucket', data: testDocument })
                     .expect(400);
@@ -86,7 +85,7 @@ describe('Private API - S3 E2E Tests', () => {
 
             it('should return 400 when data is not a JSON object', async () => {
                 const response = await request(APP_BASE_URL)
-                    .post(`/api/${API_VERSION}/private`)
+                    .post(`/api/v4/private`)
                     .set('X-API-Key', API_KEY)
                     .send({ bucket: 'documents', data: 'not-an-object' })
                     .expect(400);
@@ -96,7 +95,7 @@ describe('Private API - S3 E2E Tests', () => {
 
             it('should return 400 when id is not a valid UUID', async () => {
                 const response = await request(APP_BASE_URL)
-                    .post(`/api/${API_VERSION}/private`)
+                    .post(`/api/v4/private`)
                     .set('X-API-Key', API_KEY)
                     .send({ bucket: 'documents', id: 'not-a-uuid', data: testDocument })
                     .expect(400);
@@ -108,7 +107,7 @@ describe('Private API - S3 E2E Tests', () => {
         describe('Storage', () => {
             it('should return 201 with uri, digestMultibase, and decryptionKey', async () => {
                 const response = await request(APP_BASE_URL)
-                    .post(`/api/${API_VERSION}/private`)
+                    .post(`/api/v4/private`)
                     .set('X-API-Key', API_KEY)
                     .send({ bucket: 'documents', data: testDocument })
                     .expect(201);
@@ -124,7 +123,7 @@ describe('Private API - S3 E2E Tests', () => {
             it('should return 201 with custom UUID id', async () => {
                 const customId = uuidv4();
                 const response = await request(APP_BASE_URL)
-                    .post(`/api/${API_VERSION}/private`)
+                    .post(`/api/v4/private`)
                     .set('X-API-Key', API_KEY)
                     .send({ bucket: 'documents', id: customId, data: testDocument })
                     .expect(201);
@@ -138,13 +137,13 @@ describe('Private API - S3 E2E Tests', () => {
                 const duplicateId = uuidv4();
 
                 await request(APP_BASE_URL)
-                    .post(`/api/${API_VERSION}/private`)
+                    .post(`/api/v4/private`)
                     .set('X-API-Key', API_KEY)
                     .send({ bucket: 'documents', id: duplicateId, data: testDocument })
                     .expect(201);
 
                 const response = await request(APP_BASE_URL)
-                    .post(`/api/${API_VERSION}/private`)
+                    .post(`/api/v4/private`)
                     .set('X-API-Key', API_KEY)
                     .send({ bucket: 'documents', id: duplicateId, data: testDocument })
                     .expect(409);
@@ -156,7 +155,7 @@ describe('Private API - S3 E2E Tests', () => {
         describe('Round-trip verification', () => {
             it('should store an encrypted envelope retrievable via GET on returned URI', async () => {
                 const postResponse = await request(APP_BASE_URL)
-                    .post(`/api/${API_VERSION}/private`)
+                    .post(`/api/v4/private`)
                     .set('X-API-Key', API_KEY)
                     .send({ bucket: 'documents', data: testDocument })
                     .expect(201);
@@ -171,7 +170,7 @@ describe('Private API - S3 E2E Tests', () => {
 
             it('should return a valid encrypted envelope with cipherText, iv, tag, type, contentType', async () => {
                 const postResponse = await request(APP_BASE_URL)
-                    .post(`/api/${API_VERSION}/private`)
+                    .post(`/api/v4/private`)
                     .set('X-API-Key', API_KEY)
                     .send({ bucket: 'documents', data: testDocument })
                     .expect(201);
@@ -193,7 +192,7 @@ describe('Private API - S3 E2E Tests', () => {
         describe('Decrypt verification', () => {
             it('should decrypt the envelope with the returned key to recover the original JSON', async () => {
                 const postResponse = await request(APP_BASE_URL)
-                    .post(`/api/${API_VERSION}/private`)
+                    .post(`/api/v4/private`)
                     .set('X-API-Key', API_KEY)
                     .send({ bucket: 'documents', data: testDocument })
                     .expect(201);
@@ -211,7 +210,7 @@ describe('Private API - S3 E2E Tests', () => {
 
             it('should produce a valid multibase digest of the original (unencrypted) data', async () => {
                 const postResponse = await request(APP_BASE_URL)
-                    .post(`/api/${API_VERSION}/private`)
+                    .post(`/api/v4/private`)
                     .set('X-API-Key', API_KEY)
                     .send({ bucket: 'documents', data: testDocument })
                     .expect(201);
@@ -222,11 +221,11 @@ describe('Private API - S3 E2E Tests', () => {
         });
     });
 
-    describe(`POST /api/${API_VERSION}/private (Binary)`, () => {
+    describe(`POST /api/v4/private (Binary)`, () => {
         describe('Authentication', () => {
             it('should return 401 when API key is missing', async () => {
                 const response = await request(APP_BASE_URL)
-                    .post(`/api/${API_VERSION}/private`)
+                    .post(`/api/v4/private`)
                     .attach('file', MINIMAL_PNG, { filename: 'test.png', contentType: 'image/png' })
                     .field('bucket', 'files')
                     .expect(401);
@@ -236,7 +235,7 @@ describe('Private API - S3 E2E Tests', () => {
 
             it('should return 401 when API key is invalid', async () => {
                 const response = await request(APP_BASE_URL)
-                    .post(`/api/${API_VERSION}/private`)
+                    .post(`/api/v4/private`)
                     .set('X-API-Key', 'invalid-key')
                     .attach('file', MINIMAL_PNG, { filename: 'test.png', contentType: 'image/png' })
                     .field('bucket', 'files')
@@ -249,7 +248,7 @@ describe('Private API - S3 E2E Tests', () => {
         describe('Validation', () => {
             it('should return 400 when no file is attached', async () => {
                 const response = await request(APP_BASE_URL)
-                    .post(`/api/${API_VERSION}/private`)
+                    .post(`/api/v4/private`)
                     .set('X-API-Key', API_KEY)
                     .field('bucket', 'files')
                     .expect(400);
@@ -259,7 +258,7 @@ describe('Private API - S3 E2E Tests', () => {
 
             it('should return 400 when bucket is missing', async () => {
                 const response = await request(APP_BASE_URL)
-                    .post(`/api/${API_VERSION}/private`)
+                    .post(`/api/v4/private`)
                     .set('X-API-Key', API_KEY)
                     .attach('file', MINIMAL_PNG, { filename: 'test.png', contentType: 'image/png' })
                     .expect(400);
@@ -269,7 +268,7 @@ describe('Private API - S3 E2E Tests', () => {
 
             it('should return 400 when bucket is not in available list', async () => {
                 const response = await request(APP_BASE_URL)
-                    .post(`/api/${API_VERSION}/private`)
+                    .post(`/api/v4/private`)
                     .set('X-API-Key', API_KEY)
                     .attach('file', MINIMAL_PNG, { filename: 'test.png', contentType: 'image/png' })
                     .field('bucket', 'nonexistent-bucket')
@@ -280,7 +279,7 @@ describe('Private API - S3 E2E Tests', () => {
 
             it('should return 400 when id is not a valid UUID', async () => {
                 const response = await request(APP_BASE_URL)
-                    .post(`/api/${API_VERSION}/private`)
+                    .post(`/api/v4/private`)
                     .set('X-API-Key', API_KEY)
                     .attach('file', MINIMAL_PNG, { filename: 'test.png', contentType: 'image/png' })
                     .field('bucket', 'files')
@@ -292,7 +291,7 @@ describe('Private API - S3 E2E Tests', () => {
 
             it('should reject when MIME type is not in allow-list', async () => {
                 const response = await request(APP_BASE_URL)
-                    .post(`/api/${API_VERSION}/private`)
+                    .post(`/api/v4/private`)
                     .set('X-API-Key', API_KEY)
                     .attach('file', Buffer.from('not a real zip'), {
                         filename: 'test.zip',
@@ -306,7 +305,7 @@ describe('Private API - S3 E2E Tests', () => {
 
             it('should return 413 when file exceeds maximum allowed size', async () => {
                 const response = await request(APP_BASE_URL)
-                    .post(`/api/${API_VERSION}/private`)
+                    .post(`/api/v4/private`)
                     .set('X-API-Key', API_KEY)
                     .attach('file', OVERSIZED_FILE, { filename: 'large.png', contentType: 'image/png' })
                     .field('bucket', 'files')
@@ -319,7 +318,7 @@ describe('Private API - S3 E2E Tests', () => {
         describe('Storage', () => {
             it('should return 201 when uploading a valid PNG and return decryptionKey', async () => {
                 const response = await request(APP_BASE_URL)
-                    .post(`/api/${API_VERSION}/private`)
+                    .post(`/api/v4/private`)
                     .set('X-API-Key', API_KEY)
                     .attach('file', MINIMAL_PNG, { filename: 'test.png', contentType: 'image/png' })
                     .field('bucket', 'files')
@@ -335,7 +334,7 @@ describe('Private API - S3 E2E Tests', () => {
 
             it('should return 201 when uploading a valid PDF and return decryptionKey', async () => {
                 const response = await request(APP_BASE_URL)
-                    .post(`/api/${API_VERSION}/private`)
+                    .post(`/api/v4/private`)
                     .set('X-API-Key', API_KEY)
                     .attach('file', MINIMAL_PDF, { filename: 'test.pdf', contentType: 'application/pdf' })
                     .field('bucket', 'files')
@@ -352,7 +351,7 @@ describe('Private API - S3 E2E Tests', () => {
             it('should return 201 with a custom UUID id', async () => {
                 const customId = uuidv4();
                 const response = await request(APP_BASE_URL)
-                    .post(`/api/${API_VERSION}/private`)
+                    .post(`/api/v4/private`)
                     .set('X-API-Key', API_KEY)
                     .attach('file', MINIMAL_PNG, { filename: 'test.png', contentType: 'image/png' })
                     .field('bucket', 'files')
@@ -368,7 +367,7 @@ describe('Private API - S3 E2E Tests', () => {
                 const duplicateId = uuidv4();
 
                 await request(APP_BASE_URL)
-                    .post(`/api/${API_VERSION}/private`)
+                    .post(`/api/v4/private`)
                     .set('X-API-Key', API_KEY)
                     .attach('file', MINIMAL_PNG, { filename: 'test.png', contentType: 'image/png' })
                     .field('bucket', 'files')
@@ -376,7 +375,7 @@ describe('Private API - S3 E2E Tests', () => {
                     .expect(201);
 
                 const response = await request(APP_BASE_URL)
-                    .post(`/api/${API_VERSION}/private`)
+                    .post(`/api/v4/private`)
                     .set('X-API-Key', API_KEY)
                     .attach('file', MINIMAL_PNG, { filename: 'test.png', contentType: 'image/png' })
                     .field('bucket', 'files')
@@ -390,7 +389,7 @@ describe('Private API - S3 E2E Tests', () => {
         describe('Round-trip verification', () => {
             it('should store an encrypted envelope retrievable via GET on returned URI', async () => {
                 const postResponse = await request(APP_BASE_URL)
-                    .post(`/api/${API_VERSION}/private`)
+                    .post(`/api/v4/private`)
                     .set('X-API-Key', API_KEY)
                     .attach('file', MINIMAL_PNG, { filename: 'test.png', contentType: 'image/png' })
                     .field('bucket', 'files')
@@ -406,7 +405,7 @@ describe('Private API - S3 E2E Tests', () => {
 
             it('should return a valid encrypted envelope with cipherText, iv, tag, type, contentType', async () => {
                 const postResponse = await request(APP_BASE_URL)
-                    .post(`/api/${API_VERSION}/private`)
+                    .post(`/api/v4/private`)
                     .set('X-API-Key', API_KEY)
                     .attach('file', MINIMAL_PNG, { filename: 'test.png', contentType: 'image/png' })
                     .field('bucket', 'files')
@@ -429,7 +428,7 @@ describe('Private API - S3 E2E Tests', () => {
         describe('Decrypt verification', () => {
             it('should decrypt the envelope with the returned key to recover the original binary (base64)', async () => {
                 const postResponse = await request(APP_BASE_URL)
-                    .post(`/api/${API_VERSION}/private`)
+                    .post(`/api/v4/private`)
                     .set('X-API-Key', API_KEY)
                     .attach('file', MINIMAL_PNG, { filename: 'test.png', contentType: 'image/png' })
                     .field('bucket', 'files')
@@ -448,7 +447,7 @@ describe('Private API - S3 E2E Tests', () => {
 
             it('should produce a valid multibase digest of the original (unencrypted) file buffer', async () => {
                 const postResponse = await request(APP_BASE_URL)
-                    .post(`/api/${API_VERSION}/private`)
+                    .post(`/api/v4/private`)
                     .set('X-API-Key', API_KEY)
                     .attach('file', MINIMAL_PNG, { filename: 'test.png', contentType: 'image/png' })
                     .field('bucket', 'files')

--- a/e2e/public.s3.e2e.test.ts
+++ b/e2e/public.s3.e2e.test.ts
@@ -1,6 +1,6 @@
 import request from 'supertest';
 import { v4 as uuidv4 } from 'uuid';
-import { APP_BASE_URL, API_KEY, API_VERSION, resolveUri, computeDigestMultibase } from './helpers';
+import { APP_BASE_URL, API_KEY, resolveUri, computeDigestMultibase } from './helpers';
 
 jest.setTimeout(30000);
 
@@ -41,11 +41,11 @@ describe('Public API - S3 E2E Tests', () => {
         });
     });
 
-    describe(`POST /api/${API_VERSION}/public (JSON)`, () => {
+    describe(`POST /api/v4/public (JSON)`, () => {
         describe('Authentication', () => {
             it('should return 401 when API key is missing', async () => {
                 const response = await request(APP_BASE_URL)
-                    .post(`/api/${API_VERSION}/public`)
+                    .post(`/api/v4/public`)
                     .send({ bucket: 'documents', data: testDocument })
                     .expect(401);
 
@@ -54,7 +54,7 @@ describe('Public API - S3 E2E Tests', () => {
 
             it('should return 401 when API key is invalid', async () => {
                 const response = await request(APP_BASE_URL)
-                    .post(`/api/${API_VERSION}/public`)
+                    .post(`/api/v4/public`)
                     .set('X-API-Key', 'wrong-api-key')
                     .send({ bucket: 'documents', data: testDocument })
                     .expect(401);
@@ -66,7 +66,7 @@ describe('Public API - S3 E2E Tests', () => {
         describe('Validation', () => {
             it('should return 400 when bucket is missing', async () => {
                 const response = await request(APP_BASE_URL)
-                    .post(`/api/${API_VERSION}/public`)
+                    .post(`/api/v4/public`)
                     .set('X-API-Key', API_KEY)
                     .send({ data: { test: 'data' } })
                     .expect(400);
@@ -76,7 +76,7 @@ describe('Public API - S3 E2E Tests', () => {
 
             it('should return 400 when bucket is not in available list', async () => {
                 const response = await request(APP_BASE_URL)
-                    .post(`/api/${API_VERSION}/public`)
+                    .post(`/api/v4/public`)
                     .set('X-API-Key', API_KEY)
                     .send({ bucket: 'nonexistent', data: { test: 'data' } })
                     .expect(400);
@@ -86,7 +86,7 @@ describe('Public API - S3 E2E Tests', () => {
 
             it('should return 400 when data is not a JSON object', async () => {
                 const response = await request(APP_BASE_URL)
-                    .post(`/api/${API_VERSION}/public`)
+                    .post(`/api/v4/public`)
                     .set('X-API-Key', API_KEY)
                     .send({ bucket: 'documents', data: 'not-an-object' })
                     .expect(400);
@@ -96,7 +96,7 @@ describe('Public API - S3 E2E Tests', () => {
 
             it('should return 400 when id is not a valid UUID', async () => {
                 const response = await request(APP_BASE_URL)
-                    .post(`/api/${API_VERSION}/public`)
+                    .post(`/api/v4/public`)
                     .set('X-API-Key', API_KEY)
                     .send({ bucket: 'documents', id: 'not-a-uuid', data: { test: 'data' } })
                     .expect(400);
@@ -108,7 +108,7 @@ describe('Public API - S3 E2E Tests', () => {
         describe('Storage', () => {
             it('should return 201 with uri and digestMultibase', async () => {
                 const response = await request(APP_BASE_URL)
-                    .post(`/api/${API_VERSION}/public`)
+                    .post(`/api/v4/public`)
                     .set('X-API-Key', API_KEY)
                     .send({ bucket: 'documents', data: testDocument })
                     .expect(201);
@@ -122,7 +122,7 @@ describe('Public API - S3 E2E Tests', () => {
             it('should return 201 with custom UUID id', async () => {
                 const customId = '123e4567-e89b-12d3-a456-426614174000';
                 const response = await request(APP_BASE_URL)
-                    .post(`/api/${API_VERSION}/public`)
+                    .post(`/api/v4/public`)
                     .set('X-API-Key', API_KEY)
                     .send({ bucket: 'documents', id: customId, data: testDocument })
                     .expect(201);
@@ -135,7 +135,7 @@ describe('Public API - S3 E2E Tests', () => {
                 const duplicateId = uuidv4();
 
                 const first = await request(APP_BASE_URL)
-                    .post(`/api/${API_VERSION}/public`)
+                    .post(`/api/v4/public`)
                     .set('X-API-Key', API_KEY)
                     .send({ bucket: 'documents', id: duplicateId, data: testDocument })
                     .expect(201);
@@ -143,7 +143,7 @@ describe('Public API - S3 E2E Tests', () => {
                 expect(first.body.uri).toEqual(expect.any(String));
 
                 const second = await request(APP_BASE_URL)
-                    .post(`/api/${API_VERSION}/public`)
+                    .post(`/api/v4/public`)
                     .set('X-API-Key', API_KEY)
                     .send({ bucket: 'documents', id: duplicateId, data: testDocument })
                     .expect(409);
@@ -155,7 +155,7 @@ describe('Public API - S3 E2E Tests', () => {
         describe('Round-trip verification', () => {
             it('should store JSON and return it unchanged via GET on returned URI', async () => {
                 const response = await request(APP_BASE_URL)
-                    .post(`/api/${API_VERSION}/public`)
+                    .post(`/api/v4/public`)
                     .set('X-API-Key', API_KEY)
                     .send({ bucket: 'documents', data: testDocument })
                     .expect(201);
@@ -170,7 +170,7 @@ describe('Public API - S3 E2E Tests', () => {
 
             it('should produce a valid multibase digest of the stored data', async () => {
                 const response = await request(APP_BASE_URL)
-                    .post(`/api/${API_VERSION}/public`)
+                    .post(`/api/v4/public`)
                     .set('X-API-Key', API_KEY)
                     .send({ bucket: 'documents', data: testDocument })
                     .expect(201);
@@ -181,11 +181,11 @@ describe('Public API - S3 E2E Tests', () => {
         });
     });
 
-    describe(`POST /api/${API_VERSION}/public (Binary)`, () => {
+    describe(`POST /api/v4/public (Binary)`, () => {
         describe('Authentication', () => {
             it('should return 401 when API key is missing', async () => {
                 const response = await request(APP_BASE_URL)
-                    .post(`/api/${API_VERSION}/public`)
+                    .post(`/api/v4/public`)
                     .attach('file', MINIMAL_PNG, { filename: 'test.png', contentType: 'image/png' })
                     .field('bucket', 'files')
                     .expect(401);
@@ -195,7 +195,7 @@ describe('Public API - S3 E2E Tests', () => {
 
             it('should return 401 when API key is invalid', async () => {
                 const response = await request(APP_BASE_URL)
-                    .post(`/api/${API_VERSION}/public`)
+                    .post(`/api/v4/public`)
                     .set('X-API-Key', 'wrong-api-key')
                     .attach('file', MINIMAL_PNG, { filename: 'test.png', contentType: 'image/png' })
                     .field('bucket', 'files')
@@ -208,7 +208,7 @@ describe('Public API - S3 E2E Tests', () => {
         describe('Validation', () => {
             it('should return 400 when no file is attached', async () => {
                 const response = await request(APP_BASE_URL)
-                    .post(`/api/${API_VERSION}/public`)
+                    .post(`/api/v4/public`)
                     .set('X-API-Key', API_KEY)
                     .field('bucket', 'files')
                     .expect(400);
@@ -218,7 +218,7 @@ describe('Public API - S3 E2E Tests', () => {
 
             it('should return 400 when bucket is missing', async () => {
                 const response = await request(APP_BASE_URL)
-                    .post(`/api/${API_VERSION}/public`)
+                    .post(`/api/v4/public`)
                     .set('X-API-Key', API_KEY)
                     .attach('file', MINIMAL_PNG, { filename: 'test.png', contentType: 'image/png' })
                     .expect(400);
@@ -228,7 +228,7 @@ describe('Public API - S3 E2E Tests', () => {
 
             it('should return 400 when bucket is not in available list', async () => {
                 const response = await request(APP_BASE_URL)
-                    .post(`/api/${API_VERSION}/public`)
+                    .post(`/api/v4/public`)
                     .set('X-API-Key', API_KEY)
                     .attach('file', MINIMAL_PNG, { filename: 'test.png', contentType: 'image/png' })
                     .field('bucket', 'nonexistent-bucket')
@@ -239,7 +239,7 @@ describe('Public API - S3 E2E Tests', () => {
 
             it('should return 400 when id is not a valid UUID', async () => {
                 const response = await request(APP_BASE_URL)
-                    .post(`/api/${API_VERSION}/public`)
+                    .post(`/api/v4/public`)
                     .set('X-API-Key', API_KEY)
                     .attach('file', MINIMAL_PNG, { filename: 'test.png', contentType: 'image/png' })
                     .field('bucket', 'files')
@@ -251,7 +251,7 @@ describe('Public API - S3 E2E Tests', () => {
 
             it('should reject when MIME type is not in allow-list', async () => {
                 const response = await request(APP_BASE_URL)
-                    .post(`/api/${API_VERSION}/public`)
+                    .post(`/api/v4/public`)
                     .set('X-API-Key', API_KEY)
                     .attach('file', Buffer.from('not a real zip'), {
                         filename: 'test.zip',
@@ -265,7 +265,7 @@ describe('Public API - S3 E2E Tests', () => {
 
             it('should return 413 when file exceeds maximum allowed size', async () => {
                 const response = await request(APP_BASE_URL)
-                    .post(`/api/${API_VERSION}/public`)
+                    .post(`/api/v4/public`)
                     .set('X-API-Key', API_KEY)
                     .attach('file', OVERSIZED_FILE, { filename: 'large.png', contentType: 'image/png' })
                     .field('bucket', 'files')
@@ -278,7 +278,7 @@ describe('Public API - S3 E2E Tests', () => {
         describe('Storage', () => {
             it('should return 201 when uploading a valid PNG', async () => {
                 const response = await request(APP_BASE_URL)
-                    .post(`/api/${API_VERSION}/public`)
+                    .post(`/api/v4/public`)
                     .set('X-API-Key', API_KEY)
                     .attach('file', MINIMAL_PNG, { filename: 'test.png', contentType: 'image/png' })
                     .field('bucket', 'files')
@@ -292,7 +292,7 @@ describe('Public API - S3 E2E Tests', () => {
 
             it('should return 201 when uploading a valid PDF', async () => {
                 const response = await request(APP_BASE_URL)
-                    .post(`/api/${API_VERSION}/public`)
+                    .post(`/api/v4/public`)
                     .set('X-API-Key', API_KEY)
                     .attach('file', MINIMAL_PDF, { filename: 'test.pdf', contentType: 'application/pdf' })
                     .field('bucket', 'files')
@@ -306,7 +306,7 @@ describe('Public API - S3 E2E Tests', () => {
 
             it('should return 201 when uploading a valid JPEG', async () => {
                 const response = await request(APP_BASE_URL)
-                    .post(`/api/${API_VERSION}/public`)
+                    .post(`/api/v4/public`)
                     .set('X-API-Key', API_KEY)
                     .attach('file', Buffer.from('fake-jpeg-content'), {
                         filename: 'test.jpg',
@@ -324,7 +324,7 @@ describe('Public API - S3 E2E Tests', () => {
             it('should return 201 with a custom UUID id', async () => {
                 const customId = uuidv4();
                 const response = await request(APP_BASE_URL)
-                    .post(`/api/${API_VERSION}/public`)
+                    .post(`/api/v4/public`)
                     .set('X-API-Key', API_KEY)
                     .attach('file', MINIMAL_PNG, { filename: 'test.png', contentType: 'image/png' })
                     .field('bucket', 'files')
@@ -339,7 +339,7 @@ describe('Public API - S3 E2E Tests', () => {
                 const duplicateId = uuidv4();
 
                 const first = await request(APP_BASE_URL)
-                    .post(`/api/${API_VERSION}/public`)
+                    .post(`/api/v4/public`)
                     .set('X-API-Key', API_KEY)
                     .attach('file', MINIMAL_PNG, { filename: 'test.png', contentType: 'image/png' })
                     .field('bucket', 'files')
@@ -349,7 +349,7 @@ describe('Public API - S3 E2E Tests', () => {
                 expect(first.body.uri).toEqual(expect.any(String));
 
                 const second = await request(APP_BASE_URL)
-                    .post(`/api/${API_VERSION}/public`)
+                    .post(`/api/v4/public`)
                     .set('X-API-Key', API_KEY)
                     .attach('file', MINIMAL_PNG, { filename: 'test.png', contentType: 'image/png' })
                     .field('bucket', 'files')
@@ -363,7 +363,7 @@ describe('Public API - S3 E2E Tests', () => {
         describe('Round-trip verification', () => {
             it('should store a PNG and return the identical binary via GET on returned URI', async () => {
                 const response = await request(APP_BASE_URL)
-                    .post(`/api/${API_VERSION}/public`)
+                    .post(`/api/v4/public`)
                     .set('X-API-Key', API_KEY)
                     .attach('file', MINIMAL_PNG, { filename: 'test.png', contentType: 'image/png' })
                     .field('bucket', 'files')
@@ -379,7 +379,7 @@ describe('Public API - S3 E2E Tests', () => {
 
             it('should store a PDF and return the identical binary via GET on returned URI', async () => {
                 const response = await request(APP_BASE_URL)
-                    .post(`/api/${API_VERSION}/public`)
+                    .post(`/api/v4/public`)
                     .set('X-API-Key', API_KEY)
                     .attach('file', MINIMAL_PDF, { filename: 'test.pdf', contentType: 'application/pdf' })
                     .field('bucket', 'files')
@@ -395,7 +395,7 @@ describe('Public API - S3 E2E Tests', () => {
 
             it('should produce a valid multibase digest of the stored file', async () => {
                 const response = await request(APP_BASE_URL)
-                    .post(`/api/${API_VERSION}/public`)
+                    .post(`/api/v4/public`)
                     .set('X-API-Key', API_KEY)
                     .attach('file', MINIMAL_PNG, { filename: 'test.png', contentType: 'image/png' })
                     .field('bucket', 'files')

--- a/src/app.routing.test.ts
+++ b/src/app.routing.test.ts
@@ -1,0 +1,131 @@
+import request from 'supertest';
+import path from 'path';
+import fs from 'fs';
+import os from 'os';
+
+/**
+ * Routing-level integration tests for the v4 path layout. These tests assemble
+ * the real Express app and assert how URLs map to handlers. They are intentionally
+ * coarse: handler internals are mocked so the assertions stay focused on routing.
+ *
+ * Specifically:
+ * - `/api/v4/{public,private,:bucket/:id}` reaches the correct sub-router.
+ * - Legacy SemVer paths (`/api/3.0.0/...`, `/api/3.1.0/...`, `/api/v3/...`) return 404.
+ * - The static-file middleware mounted inside the v4 router serves files at
+ *   `/api/v4/<bucket>/<key>` and NOT at the un-prefixed `/<bucket>/<key>`.
+ */
+
+const tempUploadsDir = fs.mkdtempSync(path.join(os.tmpdir(), 'storage-service-routing-test-'));
+const TEST_BUCKET = 'test-bucket';
+const TEST_FILE = 'fixture.txt';
+const TEST_FILE_BODY = 'routing-test-fixture-contents';
+
+beforeAll(() => {
+    fs.mkdirSync(path.join(tempUploadsDir, TEST_BUCKET), { recursive: true });
+    fs.writeFileSync(path.join(tempUploadsDir, TEST_BUCKET, TEST_FILE), TEST_FILE_BODY);
+});
+
+afterAll(() => {
+    fs.rmSync(tempUploadsDir, { recursive: true, force: true });
+});
+
+jest.mock('./config', () => ({
+    PROTOCOL: 'http',
+    DOMAIN: 'localhost',
+    PORT: 3333,
+    EXTERNAL_PORT: 3333,
+    DEFAULT_BUCKET: undefined,
+    AVAILABLE_BUCKETS: ['test-bucket'],
+    STORAGE_TYPE: 'local',
+    LOCAL_DIRECTORY: tempUploadsDir,
+    MAX_UPLOAD_SIZE: 10 * 1024 * 1024,
+    getApiKey: jest.fn(() => 'test-api-key'),
+    AUTH_HEADER_NAME: 'x-api-key',
+    __filename: '',
+    __dirname: '',
+}));
+
+// Stub the route controllers so the routing tests are independent of handler logic.
+// Each stub responds with a status that uniquely identifies the handler that ran,
+// so a 404 means the route did not resolve (which is what we want to assert for
+// legacy SemVer paths).
+jest.mock('./routes/v4/public/controller', () => ({
+    storePublic: (_req: any, res: any) => res.status(201).json({ handler: 'public' }),
+}));
+jest.mock('./routes/v4/private/controller', () => ({
+    storePrivate: (_req: any, res: any) => res.status(201).json({ handler: 'private' }),
+}));
+jest.mock('./routes/v4/delete/controller', () => ({
+    deleteResource: (_req: any, res: any) => res.status(204).end(),
+}));
+
+// eslint-disable-next-line @typescript-eslint/no-var-requires
+const { app } = require('./app');
+
+const API_KEY_HEADER = { 'x-api-key': 'test-api-key' };
+
+describe('App routing layout', () => {
+    describe('/api/v4 routes', () => {
+        it('mounts the public router at POST /api/v4/public', async () => {
+            const response = await request(app).post('/api/v4/public').set(API_KEY_HEADER).send({});
+            expect(response.status).toBe(201);
+            expect(response.body).toEqual({ handler: 'public' });
+        });
+
+        it('mounts the private router at POST /api/v4/private', async () => {
+            const response = await request(app).post('/api/v4/private').set(API_KEY_HEADER).send({});
+            expect(response.status).toBe(201);
+            expect(response.body).toEqual({ handler: 'private' });
+        });
+
+        it('mounts the delete router at DELETE /api/v4/:bucket/:id', async () => {
+            const response = await request(app).delete('/api/v4/test-bucket/some-id').set(API_KEY_HEADER);
+            expect(response.status).toBe(204);
+        });
+    });
+
+    describe('legacy SemVer paths return 404', () => {
+        // Versioning is part of the public API contract. If a future refactor accidentally
+        // reintroduces a backward-compat alias these tests fail loudly.
+        it.each([
+            ['POST', '/api/3.0.0/public'],
+            ['POST', '/api/3.1.0/public'],
+            ['POST', '/api/3.0.0/private'],
+            ['POST', '/api/3.1.0/private'],
+            ['POST', '/api/v3/public'],
+        ])('%s %s returns 404', async (method, url) => {
+            const response =
+                method === 'POST'
+                    ? await request(app).post(url).set(API_KEY_HEADER).send({})
+                    : await request(app).get(url).set(API_KEY_HEADER);
+            expect(response.status).toBe(404);
+        });
+    });
+
+    describe('static file serving inside the v4 router', () => {
+        it('serves files at /api/v4/<bucket>/<key>', async () => {
+            const response = await request(app).get(`/api/v4/${TEST_BUCKET}/${TEST_FILE}`);
+            expect(response.status).toBe(200);
+            expect(response.text).toBe(TEST_FILE_BODY);
+        });
+
+        it('does not serve files at the un-prefixed /<bucket>/<key>', async () => {
+            const response = await request(app).get(`/${TEST_BUCKET}/${TEST_FILE}`);
+            expect(response.status).toBe(404);
+        });
+
+        it('returns 404 for missing files under /api/v4/', async () => {
+            const response = await request(app).get('/api/v4/test-bucket/does-not-exist.txt');
+            expect(response.status).toBe(404);
+        });
+    });
+
+    describe('health-check stays at the top level', () => {
+        it('responds at /health-check (not /api/v4/health-check)', async () => {
+            const ok = await request(app).get('/health-check');
+            expect(ok.status).toBe(200);
+            const notFound = await request(app).get('/api/v4/health-check');
+            expect(notFound.status).toBe(404);
+        });
+    });
+});

--- a/src/app.ts
+++ b/src/app.ts
@@ -5,7 +5,7 @@ import bodyParser from 'body-parser';
 import { router } from './routes';
 import swaggerDocument from './swagger/swagger.json';
 import { updateSwagger } from './swagger/helpers';
-import { API_VERSION, DOMAIN, EXTERNAL_PORT, MAX_UPLOAD_SIZE, PROTOCOL } from './config';
+import { DOMAIN, EXTERNAL_PORT, MAX_UPLOAD_SIZE, PROTOCOL } from './config';
 import { buildBaseUrl } from './utils';
 import { apiLogger as logger } from './services/logging';
 import { correlationIdMiddleware } from './middleware/correlation-id';
@@ -23,8 +23,8 @@ app.use(
     (req: any, res: any, next: any) => {
         // Build the Swagger server URL from config rather than request internals (req.protocol,
         // req.hostname, req.socket.localPort) which reflect the container's internal address.
-        const url = buildBaseUrl(PROTOCOL, DOMAIN, EXTERNAL_PORT, `api/${API_VERSION}`);
-        swaggerJson = updateSwagger(swaggerJson, { version: API_VERSION, url });
+        const url = buildBaseUrl(PROTOCOL, DOMAIN, EXTERNAL_PORT, 'api/v4');
+        swaggerJson = updateSwagger(swaggerJson, { version: 'v4', url });
         req.swaggerDoc = swaggerJson;
         next();
     },
@@ -41,7 +41,7 @@ app.get('/health-check', (req, res) => {
     res.send('OK');
 });
 
-app.use(`/api/${API_VERSION}`, router);
+app.use('/api', router);
 
 // Global error handler for unhandled errors
 app.use((err: any, _req: Request, res: Response, _next: NextFunction) => {

--- a/src/app.ts
+++ b/src/app.ts
@@ -5,7 +5,7 @@ import bodyParser from 'body-parser';
 import { router } from './routes';
 import swaggerDocument from './swagger/swagger.json';
 import { updateSwagger } from './swagger/helpers';
-import { DOMAIN, EXTERNAL_PORT, MAX_UPLOAD_SIZE, PROTOCOL } from './config';
+import { API_VERSION, DOMAIN, EXTERNAL_PORT, MAX_UPLOAD_SIZE, PROTOCOL } from './config';
 import { buildBaseUrl } from './utils';
 import { apiLogger as logger } from './services/logging';
 import { correlationIdMiddleware } from './middleware/correlation-id';
@@ -24,7 +24,7 @@ app.use(
         // Build the Swagger server URL from config rather than request internals (req.protocol,
         // req.hostname, req.socket.localPort) which reflect the container's internal address.
         const url = buildBaseUrl(PROTOCOL, DOMAIN, EXTERNAL_PORT, 'api/v4');
-        swaggerJson = updateSwagger(swaggerJson, { version: 'v4', url });
+        swaggerJson = updateSwagger(swaggerJson, { version: API_VERSION, url });
         req.swaggerDoc = swaggerJson;
         next();
     },

--- a/src/config.ts
+++ b/src/config.ts
@@ -3,10 +3,27 @@
 import dotenv from 'dotenv';
 dotenv.config();
 
+import fs from 'fs';
 import { dirname } from 'path';
 import { fileURLToPath } from 'url';
 import { getBucketConfiguration } from './bucket-config';
 import { createPublicUriGenerator } from './public-url';
+
+const VERSION_FILE = 'version.json';
+
+// apiVersion is the MAJOR.MINOR pair the API contract publishes. It is kept in
+// lockstep with the URL path version segment under src/routes/v<MAJOR>/: the
+// MAJOR of apiVersion always equals the MAJOR in the URL. MINOR bumps document
+// backwards-compatible additions and do not change the URL.
+export const getApiVersion = () => {
+    const version = fs.readFileSync(VERSION_FILE, 'utf8');
+    const { apiVersion } = JSON.parse(version);
+
+    if (!apiVersion) throw Error('API version not found');
+    return apiVersion;
+};
+
+export const API_VERSION = getApiVersion();
 
 export const PROTOCOL = process.env.PROTOCOL || 'http';
 export const DOMAIN = process.env.DOMAIN || 'localhost';

--- a/src/config.ts
+++ b/src/config.ts
@@ -3,23 +3,11 @@
 import dotenv from 'dotenv';
 dotenv.config();
 
-import fs from 'fs';
 import { dirname } from 'path';
 import { fileURLToPath } from 'url';
 import { getBucketConfiguration } from './bucket-config';
 import { createPublicUriGenerator } from './public-url';
-const VERSION_FILE = 'version.json';
 
-// The API_VERSION is set manually, it should be updated when having change impact on the API.
-const getApiVersion = () => {
-    const version = fs.readFileSync(VERSION_FILE, 'utf8');
-    const { apiVersion } = JSON.parse(version);
-
-    if (!apiVersion) throw Error('API version not found');
-    return apiVersion;
-};
-
-export const API_VERSION = getApiVersion();
 export const PROTOCOL = process.env.PROTOCOL || 'http';
 export const DOMAIN = process.env.DOMAIN || 'localhost';
 export const PORT = process.env.PORT || 3333;

--- a/src/routes/index.ts
+++ b/src/routes/index.ts
@@ -1,13 +1,6 @@
-import express, { Router } from 'express';
-import path from 'path';
-import { publicRouter } from './public';
-import { privateRouter } from './private';
-import { deleteRouter } from './delete';
-import { LOCAL_DIRECTORY, __dirname } from '../config';
+import { Router } from 'express';
+import { v4Router } from './v4';
 
 export const router = Router();
 
-router.use('/public', publicRouter);
-router.use('/private', privateRouter);
-router.use('/', deleteRouter);
-router.use(express.static(path.join(__dirname, LOCAL_DIRECTORY)));
+router.use('/v4', v4Router);

--- a/src/routes/v4/delete/controller.test.ts
+++ b/src/routes/v4/delete/controller.test.ts
@@ -1,16 +1,16 @@
 import { getMockReq, getMockRes } from '@jest-mock/express';
 import { deleteResource } from './controller';
 import { DeleteService } from './service';
-import { BadRequestError, NotFoundError } from '../../errors';
+import { BadRequestError, NotFoundError } from '../../../errors';
 
 const { res: mockRes, next: mockNext, clearMockRes } = getMockRes();
 
-jest.mock('../../config', () => ({
+jest.mock('../../../config', () => ({
     AVAILABLE_BUCKETS: ['my-bucket'],
     STORAGE_TYPE: 'gcp',
 }));
 
-jest.mock('../../services/storage/gcp', () => ({
+jest.mock('../../../services/storage/gcp', () => ({
     GCPStorageService: jest.fn().mockImplementation(() => ({
         uploadFile: jest.fn(),
         objectExists: jest.fn(),

--- a/src/routes/v4/delete/controller.ts
+++ b/src/routes/v4/delete/controller.ts
@@ -1,8 +1,8 @@
 import { RequestHandler } from 'express';
-import { initialiseStorageService, IStorageService } from '../../services';
+import { initialiseStorageService, IStorageService } from '../../../services';
 import { DeleteService } from './service';
-import { ApiError } from '../../errors';
-import { apiLogger } from '../../services/logging';
+import { ApiError } from '../../../errors';
+import { apiLogger } from '../../../services/logging';
 
 const logger = apiLogger.child({ route: 'DELETE /:bucket/:id' });
 

--- a/src/routes/v4/delete/index.ts
+++ b/src/routes/v4/delete/index.ts
@@ -1,6 +1,6 @@
 import { Router } from 'express';
 import { deleteResource } from './controller';
-import { authenticateRequest } from '../../middleware/authentication';
+import { authenticateRequest } from '../../../middleware/authentication';
 
 export const deleteRouter = Router();
 

--- a/src/routes/v4/delete/service.test.ts
+++ b/src/routes/v4/delete/service.test.ts
@@ -1,8 +1,8 @@
-import { IStorageService } from '../../services';
+import { IStorageService } from '../../../services';
 import { DeleteService } from './service';
-import { BadRequestError, NotFoundError, ApplicationError } from '../../errors';
+import { BadRequestError, NotFoundError, ApplicationError } from '../../../errors';
 
-jest.mock('../../config', () => ({
+jest.mock('../../../config', () => ({
     AVAILABLE_BUCKETS: ['my-bucket'],
 }));
 

--- a/src/routes/v4/delete/service.ts
+++ b/src/routes/v4/delete/service.ts
@@ -1,8 +1,8 @@
-import { IStorageService } from '../../services';
-import { ApiError, ApplicationError, BadRequestError, NotFoundError } from '../../errors';
-import { AVAILABLE_BUCKETS } from '../../config';
-import { isValidUUID } from '../../utils';
-import { apiLogger as logger } from '../../services/logging';
+import { IStorageService } from '../../../services';
+import { ApiError, ApplicationError, BadRequestError, NotFoundError } from '../../../errors';
+import { AVAILABLE_BUCKETS } from '../../../config';
+import { isValidUUID } from '../../../utils';
+import { apiLogger as logger } from '../../../services/logging';
 
 export class DeleteService {
     public async deleteDocument(storageService: IStorageService, bucket: string, id: string): Promise<void> {

--- a/src/routes/v4/index.ts
+++ b/src/routes/v4/index.ts
@@ -1,0 +1,13 @@
+import express, { Router } from 'express';
+import path from 'path';
+import { publicRouter } from './public';
+import { privateRouter } from './private';
+import { deleteRouter } from './delete';
+import { LOCAL_DIRECTORY, __dirname } from '../../config';
+
+export const v4Router = Router();
+
+v4Router.use('/public', publicRouter);
+v4Router.use('/private', privateRouter);
+v4Router.use('/', deleteRouter);
+v4Router.use(express.static(path.join(__dirname, LOCAL_DIRECTORY)));

--- a/src/routes/v4/private/controller.test.ts
+++ b/src/routes/v4/private/controller.test.ts
@@ -1,4 +1,3 @@
-import fs from 'fs';
 import os from 'os';
 import path from 'path';
 import { getMockReq, getMockRes } from '@jest-mock/express';
@@ -12,7 +11,7 @@ const mockLogger: any = {
 };
 mockLogger.child = jest.fn(() => mockLogger);
 
-jest.mock('../../services/logging', () => ({
+jest.mock('../../../services/logging', () => ({
     getLogger: () => mockLogger,
     apiLogger: mockLogger,
     authLogger: mockLogger,
@@ -22,77 +21,86 @@ jest.mock('../../services/logging', () => ({
     serverLogger: mockLogger,
 }));
 
-import { storePublic } from './controller';
-import { PublicService } from './service';
-import { BadRequestError } from '../../errors';
+import { BadRequestError } from '../../../errors';
+import { PrivateService } from './service';
 
 const { res: mockRes, next: mockNext, clearMockRes } = getMockRes();
 
-jest.mock('../../config', () => ({
+jest.mock('../../../config', () => ({
     AVAILABLE_BUCKETS: ['bucketName'],
     STORAGE_TYPE: 'gcp',
 }));
 
-jest.mock('../../services/storage/gcp', () => ({
+jest.mock('../../../services/cryptography', () => ({
+    CryptographyService: jest.fn().mockImplementation(() => ({
+        computeDigestMultibase: jest.fn().mockResolvedValue('mocked-digest'),
+        generateEncryptionKey: jest.fn().mockResolvedValue('test-encryption-key'),
+        encryptString: jest
+            .fn()
+            .mockReturnValue({ cipherText: 'encrypted', iv: 'test-iv', tag: 'test-tag', type: 'aes-256-gcm' }),
+    })),
+}));
+
+jest.mock('../../../services/storage/gcp', () => ({
     GCPStorageService: jest.fn().mockImplementation(() => ({
         uploadFile: jest.fn().mockResolvedValue({ uri: 'mock-uri' }),
         objectExists: jest.fn().mockResolvedValue(false),
     })),
 }));
 
-jest.mock('../../services/cryptography', () => ({
-    CryptographyService: jest.fn().mockImplementation(() => ({
-        computeDigestMultibase: jest.fn().mockResolvedValue('mocked-digest'),
-    })),
-}));
-
 jest.mock('fs', () => ({
     ...jest.requireActual('fs'),
     promises: {
-        readFile: jest.fn().mockResolvedValue(Buffer.from('fake-binary-content')),
+        readFile: jest.fn().mockResolvedValue(Buffer.from('binary-content')),
         unlink: jest.fn().mockResolvedValue(undefined),
     },
 }));
 
-describe('PublicController', () => {
+import fs from 'fs';
+import { storePrivate } from './controller';
+
+describe('Private Controller', () => {
     beforeEach(() => {
         clearMockRes();
         jest.clearAllMocks();
     });
 
-    describe('storePublic', () => {
-        it('should successfully store a JSON document and return 201 with uri and digestMultibase', async () => {
-            const storeDocumentSpy = jest.spyOn(PublicService.prototype, 'storeDocument').mockResolvedValue({
+    describe('storePrivate', () => {
+        it('should successfully store a JSON document and return 201', async () => {
+            const spy = jest.spyOn(PrivateService.prototype, 'encryptAndStoreDocument').mockResolvedValue({
                 uri: 'mock-uri',
                 digestMultibase: 'mocked-digest',
+                decryptionKey: 'test-encryption-key',
             });
 
             const mockReq = getMockReq({
                 body: {
                     bucket: 'bucketName',
-                    id: '123e4567-e89b-12d3-a456-426614174000',
-                    data: { name: 'test' },
+                    id: '550e8400-e29b-41d4-a716-446655440000',
+                    data: { key: 'value' },
                 },
             });
 
-            await storePublic(mockReq, mockRes, mockNext);
+            await storePrivate(mockReq, mockRes, mockNext);
 
             expect(mockRes.status).toHaveBeenCalledWith(201);
             expect(mockRes.json).toHaveBeenCalledWith({
                 uri: 'mock-uri',
                 digestMultibase: 'mocked-digest',
+                decryptionKey: 'test-encryption-key',
             });
-            expect(storeDocumentSpy).toHaveBeenCalledWith(
+            expect(spy).toHaveBeenCalledWith(
                 expect.anything(), // storageService
-                expect.anything(), // cryptoService
-                { bucket: 'bucketName', id: '123e4567-e89b-12d3-a456-426614174000', data: { name: 'test' } },
+                expect.anything(), // cryptographyService
+                { bucket: 'bucketName', id: '550e8400-e29b-41d4-a716-446655440000', data: { key: 'value' } },
             );
         });
 
-        it('should successfully store a binary file and return 201 with uri and digestMultibase', async () => {
-            const storeFileSpy = jest.spyOn(PublicService.prototype, 'storeFile').mockResolvedValue({
-                uri: 'mock-file-uri',
-                digestMultibase: 'mocked-file-digest',
+        it('should successfully store a binary file and return 201', async () => {
+            const spy = jest.spyOn(PrivateService.prototype, 'encryptAndStoreFile').mockResolvedValue({
+                uri: 'mock-uri',
+                digestMultibase: 'mocked-digest',
+                decryptionKey: 'test-encryption-key',
             });
 
             const tempFilePath = path.join(os.tmpdir(), 'upload-12345');
@@ -100,27 +108,28 @@ describe('PublicController', () => {
                 file: {
                     path: tempFilePath,
                     mimetype: 'image/png',
-                } as Express.Multer.File,
+                } as any,
                 body: {
                     bucket: 'bucketName',
-                    id: '123e4567-e89b-12d3-a456-426614174000',
+                    id: '550e8400-e29b-41d4-a716-446655440000',
                 },
             });
 
-            await storePublic(mockReq, mockRes, mockNext);
+            await storePrivate(mockReq, mockRes, mockNext);
 
             expect(fs.promises.readFile).toHaveBeenCalledWith(path.resolve(tempFilePath));
             expect(mockRes.status).toHaveBeenCalledWith(201);
             expect(mockRes.json).toHaveBeenCalledWith({
-                uri: 'mock-file-uri',
-                digestMultibase: 'mocked-file-digest',
+                uri: 'mock-uri',
+                digestMultibase: 'mocked-digest',
+                decryptionKey: 'test-encryption-key',
             });
-            expect(storeFileSpy).toHaveBeenCalledWith(
-                expect.anything(), // storageService
-                expect.anything(), // cryptoService
+            expect(spy).toHaveBeenCalledWith(
+                expect.anything(),
+                expect.anything(),
                 expect.objectContaining({
                     bucket: 'bucketName',
-                    id: '123e4567-e89b-12d3-a456-426614174000',
+                    id: '550e8400-e29b-41d4-a716-446655440000',
                     file: expect.any(Buffer),
                     mimeType: 'image/png',
                 }),
@@ -128,18 +137,18 @@ describe('PublicController', () => {
         });
 
         it('should return 400 for an invalid bucket', async () => {
-            jest.spyOn(PublicService.prototype, 'storeDocument').mockRejectedValue(
+            jest.spyOn(PrivateService.prototype, 'encryptAndStoreDocument').mockRejectedValue(
                 new BadRequestError('Invalid bucket. Must be one of the following buckets: bucketName'),
             );
 
             const mockReq = getMockReq({
                 body: {
-                    bucket: 'invalid-bucket',
-                    data: { name: 'test' },
+                    bucket: 'invalidBucket',
+                    data: { key: 'value' },
                 },
             });
 
-            await storePublic(mockReq, mockRes, mockNext);
+            await storePrivate(mockReq, mockRes, mockNext);
 
             expect(mockRes.status).toHaveBeenCalledWith(400);
             expect(mockRes.json).toHaveBeenCalledWith({
@@ -147,23 +156,23 @@ describe('PublicController', () => {
             });
         });
 
-        it('should return 500 for unexpected errors', async () => {
-            jest.spyOn(PublicService.prototype, 'storeDocument').mockRejectedValue(
+        it('should return 500 when a non-ApiError is thrown', async () => {
+            jest.spyOn(PrivateService.prototype, 'encryptAndStoreDocument').mockRejectedValue(
                 new Error('Something went terribly wrong'),
             );
 
             const mockReq = getMockReq({
                 body: {
                     bucket: 'bucketName',
-                    data: { name: 'test' },
+                    data: { key: 'value' },
                 },
             });
 
-            await storePublic(mockReq, mockRes, mockNext);
+            await storePrivate(mockReq, mockRes, mockNext);
 
             expect(mockRes.status).toHaveBeenCalledWith(500);
             expect(mockRes.json).toHaveBeenCalledWith({
-                message: 'An unexpected error occurred while storing the resource.',
+                message: 'An unexpected error occurred while storing private data.',
             });
         });
 
@@ -171,7 +180,7 @@ describe('PublicController', () => {
             const mockReq = getMockReq({
                 body: {
                     bucket: 'bucketName',
-                    id: '123e4567-e89b-12d3-a456-426614174000',
+                    id: '550e8400-e29b-41d4-a716-446655440000',
                 },
             });
             mockReq.is = jest.fn((type: string) =>
@@ -179,7 +188,7 @@ describe('PublicController', () => {
             ) as any;
             mockReq.file = undefined;
 
-            await storePublic(mockReq, mockRes, mockNext);
+            await storePrivate(mockReq, mockRes, mockNext);
 
             expect(mockRes.status).toHaveBeenCalledWith(400);
             expect(mockRes.json).toHaveBeenCalledWith({
@@ -188,41 +197,45 @@ describe('PublicController', () => {
         });
 
         it('should clean up the temporary file after a binary upload', async () => {
-            jest.spyOn(PublicService.prototype, 'storeFile').mockResolvedValue({
-                uri: 'mock-file-uri',
-                digestMultibase: 'mocked-file-digest',
-            });
-
-            const tempFilePath = path.join(os.tmpdir(), 'upload-cleanup-test');
-            const mockReq = getMockReq({
-                file: {
-                    path: tempFilePath,
-                    mimetype: 'image/png',
-                } as Express.Multer.File,
-                body: {
-                    bucket: 'bucketName',
-                },
-            });
-
-            await storePublic(mockReq, mockRes, mockNext);
-
-            expect(fs.promises.unlink).toHaveBeenCalledWith(path.resolve(tempFilePath));
-        });
-        it('should not attempt to clean up when there is no temporary file', async () => {
-            jest.spyOn(PublicService.prototype, 'storeDocument').mockResolvedValue({
+            jest.spyOn(PrivateService.prototype, 'encryptAndStoreFile').mockResolvedValue({
                 uri: 'mock-uri',
                 digestMultibase: 'mocked-digest',
+                decryptionKey: 'test-encryption-key',
+            });
+
+            const tempPath = path.join(os.tmpdir(), 'upload-cleanup-test');
+            const mockReq = getMockReq({
+                file: {
+                    path: tempPath,
+                    mimetype: 'image/png',
+                } as any,
+                body: {
+                    bucket: 'bucketName',
+                    id: '550e8400-e29b-41d4-a716-446655440000',
+                },
+            });
+
+            await storePrivate(mockReq, mockRes, mockNext);
+
+            expect(fs.promises.unlink).toHaveBeenCalledWith(path.resolve(tempPath));
+        });
+
+        it('should not attempt to clean up when there is no temporary file', async () => {
+            jest.spyOn(PrivateService.prototype, 'encryptAndStoreDocument').mockResolvedValue({
+                uri: 'mock-uri',
+                digestMultibase: 'mocked-digest',
+                decryptionKey: 'test-encryption-key',
             });
 
             const mockReq = getMockReq({
                 body: {
                     bucket: 'bucketName',
-                    id: '123e4567-e89b-12d3-a456-426614174000',
-                    data: { name: 'test' },
+                    id: '550e8400-e29b-41d4-a716-446655440000',
+                    data: { key: 'value' },
                 },
             });
 
-            await storePublic(mockReq, mockRes, mockNext);
+            await storePrivate(mockReq, mockRes, mockNext);
 
             expect(fs.promises.unlink).not.toHaveBeenCalled();
         });
@@ -235,13 +248,13 @@ describe('PublicController', () => {
                 file: {
                     path: tempPath,
                     mimetype: 'image/png',
-                } as Express.Multer.File,
+                } as any,
                 body: {
                     bucket: 'bucketName',
                 },
             });
 
-            await storePublic(mockReq, mockRes, mockNext);
+            await storePrivate(mockReq, mockRes, mockNext);
 
             expect(fs.promises.unlink).toHaveBeenCalledWith(path.resolve(tempPath));
         });
@@ -251,9 +264,10 @@ describe('PublicController', () => {
                 Object.assign(new Error('EACCES: permission denied'), { code: 'EACCES' }),
             );
 
-            jest.spyOn(PublicService.prototype, 'storeFile').mockResolvedValue({
+            jest.spyOn(PrivateService.prototype, 'encryptAndStoreFile').mockResolvedValue({
                 uri: 'mock-uri',
                 digestMultibase: 'mocked-digest',
+                decryptionKey: 'test-encryption-key',
             });
 
             const tempPath = path.join(os.tmpdir(), 'upload-unlink-error');
@@ -262,7 +276,7 @@ describe('PublicController', () => {
                 body: { bucket: 'bucketName', id: '550e8400-e29b-41d4-a716-446655440000' },
             });
 
-            await storePublic(mockReq, mockRes, mockNext);
+            await storePrivate(mockReq, mockRes, mockNext);
 
             expect(fs.promises.unlink).toHaveBeenCalledWith(path.resolve(tempPath));
             expect(mockLogger.error).toHaveBeenCalledWith(
@@ -276,14 +290,14 @@ describe('PublicController', () => {
                 file: {
                     path: '/etc/passwd',
                     mimetype: 'application/octet-stream',
-                } as Express.Multer.File,
+                } as any,
                 body: {
                     bucket: 'bucketName',
-                    id: '123e4567-e89b-12d3-a456-426614174000',
+                    id: '550e8400-e29b-41d4-a716-446655440000',
                 },
             });
 
-            await storePublic(mockReq, mockRes, mockNext);
+            await storePrivate(mockReq, mockRes, mockNext);
 
             expect(mockRes.status).toHaveBeenCalledWith(400);
             expect(mockRes.json).toHaveBeenCalledWith({

--- a/src/routes/v4/private/controller.ts
+++ b/src/routes/v4/private/controller.ts
@@ -5,7 +5,7 @@ import { RequestHandler } from 'express';
 import { CryptographyService, IStorageService, initialiseStorageService } from '../../../services';
 import { ApiError, BadRequestError } from '../../../errors';
 import { PrivateService } from './service';
-import { apiLogger } from '../../services/logging';
+import { apiLogger } from '../../../services/logging';
 
 const logger = apiLogger.child({ route: 'POST /private' });
 const UPLOAD_DIR = path.resolve(os.tmpdir());

--- a/src/routes/v4/private/controller.ts
+++ b/src/routes/v4/private/controller.ts
@@ -2,35 +2,35 @@ import fs from 'fs';
 import path from 'path';
 import os from 'os';
 import { RequestHandler } from 'express';
-import { initialiseStorageService, CryptographyService, IStorageService } from '../../services';
-import { PublicService } from './service';
-import { ApiError, BadRequestError } from '../../errors';
+import { CryptographyService, IStorageService, initialiseStorageService } from '../../../services';
+import { ApiError, BadRequestError } from '../../../errors';
+import { PrivateService } from './service';
 import { apiLogger } from '../../services/logging';
 
-const logger = apiLogger.child({ route: 'POST /public' });
+const logger = apiLogger.child({ route: 'POST /private' });
 const UPLOAD_DIR = path.resolve(os.tmpdir());
 
 /**
- * Handles the request to store a public document or file.
+ * Handles the request to store private data (JSON or binary) with encryption.
  *
- * For multipart/form-data requests (binary uploads), reads the uploaded file
- * from the temporary path, stores it via PublicService.storeFile(), and cleans
- * up the temporary file afterwards.
+ * For binary uploads (multipart/form-data), the file is read from the temporary
+ * path, encrypted, and stored. The temporary file is cleaned up in a finally block.
  *
- * For JSON requests, extracts parameters from the request body and stores the
- * document via PublicService.storeDocument().
+ * For JSON uploads, the body parameters are passed directly to the service for
+ * encryption and storage.
  *
- * @param req The request object.
+ * @param req The request object containing either a file upload or JSON body.
  * @param res The response object.
- * @returns The response with the stored URI and multibase digest.
+ * @returns A JSON response with the stored item's URI, multibase digest, and decryption key on success,
+ *          or an error message with an appropriate status code on failure.
  */
-export const storePublic: RequestHandler = async (req, res) => {
+export const storePrivate: RequestHandler = async (req, res) => {
     let tempPath: string | undefined;
 
     try {
-        const publicService = new PublicService();
+        const privateService = new PrivateService();
         const storageService: IStorageService = initialiseStorageService();
-        const cryptoService = new CryptographyService();
+        const cryptographyService = new CryptographyService();
 
         let response;
 
@@ -42,7 +42,7 @@ export const storePublic: RequestHandler = async (req, res) => {
             tempPath = resolvedPath;
             const fileBuffer = await fs.promises.readFile(tempPath);
 
-            response = await publicService.storeFile(storageService, cryptoService, {
+            response = await privateService.encryptAndStoreFile(storageService, cryptographyService, {
                 bucket: req.body.bucket,
                 id: req.body.id,
                 file: fileBuffer,
@@ -53,19 +53,19 @@ export const storePublic: RequestHandler = async (req, res) => {
         } else {
             const params = req.body;
 
-            response = await publicService.storeDocument(storageService, cryptoService, params);
+            response = await privateService.encryptAndStoreDocument(storageService, cryptographyService, params);
         }
 
         res.status(201).json(response);
     } catch (err: any) {
-        logger.error({ err }, '[PublicController.storePublic] An error occurred while storing the resource');
+        logger.error({ err }, '[PrivateController.storePrivate] An error occurred while storing private data');
 
         if (err instanceof ApiError) {
             return res.status(err.statusCode).json({ message: err.message });
         }
 
         res.status(500).json({
-            message: 'An unexpected error occurred while storing the resource.',
+            message: 'An unexpected error occurred while storing private data.',
         });
     } finally {
         if (tempPath && tempPath.startsWith(UPLOAD_DIR + path.sep)) {
@@ -75,7 +75,7 @@ export const storePublic: RequestHandler = async (req, res) => {
                 if (cleanupErr.code !== 'ENOENT') {
                     logger.error(
                         { tempPath, err: cleanupErr },
-                        '[PublicController.storePublic] Failed to clean up temp file',
+                        '[PrivateController.storePrivate] Failed to clean up temp file',
                     );
                 }
             }

--- a/src/routes/v4/private/index.ts
+++ b/src/routes/v4/private/index.ts
@@ -1,7 +1,7 @@
 import { Router } from 'express';
 import { storePrivate } from './controller';
-import { authenticateRequest } from '../../middleware/authentication';
-import { conditionalUpload, handleUploadError } from '../../middleware/upload';
+import { authenticateRequest } from '../../../middleware/authentication';
+import { conditionalUpload, handleUploadError } from '../../../middleware/upload';
 
 export const privateRouter = Router();
 

--- a/src/routes/v4/private/service.test.ts
+++ b/src/routes/v4/private/service.test.ts
@@ -1,7 +1,7 @@
 import { PrivateService } from './service';
-import { BadRequestError, ConflictError, ApplicationError } from '../../errors';
+import { BadRequestError, ConflictError, ApplicationError } from '../../../errors';
 
-jest.mock('../../config', () => ({
+jest.mock('../../../config', () => ({
     AVAILABLE_BUCKETS: ['bucketName'],
     ALLOWED_UPLOAD_TYPES: ['image/png', 'image/jpeg', 'application/pdf'],
     DEFAULT_BUCKET: undefined,
@@ -242,7 +242,7 @@ describe('PrivateService', () => {
         });
 
         it('should use DEFAULT_BUCKET when bucket is not provided', async () => {
-            const configModule = require('../../config');
+            const configModule = require('../../../config');
             configModule.DEFAULT_BUCKET = 'bucketName';
 
             try {
@@ -275,7 +275,7 @@ describe('PrivateService', () => {
         });
 
         it('should use DEFAULT_BUCKET when bucket is an empty string', async () => {
-            const configModule = require('../../config');
+            const configModule = require('../../../config');
             configModule.DEFAULT_BUCKET = 'bucketName';
 
             try {
@@ -309,7 +309,7 @@ describe('PrivateService', () => {
         });
 
         it('should prefer explicit bucket over DEFAULT_BUCKET', async () => {
-            const configModule = require('../../config');
+            const configModule = require('../../../config');
             configModule.DEFAULT_BUCKET = 'some-other-default';
 
             try {
@@ -624,7 +624,7 @@ describe('PrivateService', () => {
         });
 
         it('should use DEFAULT_BUCKET when bucket is not provided', async () => {
-            const configModule = require('../../config');
+            const configModule = require('../../../config');
             configModule.DEFAULT_BUCKET = 'bucketName';
 
             try {
@@ -658,7 +658,7 @@ describe('PrivateService', () => {
         });
 
         it('should use DEFAULT_BUCKET when bucket is an empty string', async () => {
-            const configModule = require('../../config');
+            const configModule = require('../../../config');
             configModule.DEFAULT_BUCKET = 'bucketName';
 
             try {
@@ -693,7 +693,7 @@ describe('PrivateService', () => {
         });
 
         it('should prefer explicit bucket over DEFAULT_BUCKET', async () => {
-            const configModule = require('../../config');
+            const configModule = require('../../../config');
             configModule.DEFAULT_BUCKET = 'some-other-default';
 
             try {

--- a/src/routes/v4/private/service.ts
+++ b/src/routes/v4/private/service.ts
@@ -1,11 +1,11 @@
 import { isPlainObject } from 'lodash';
 import { v4 } from 'uuid';
-import { IStorageService, ICryptographyService } from '../../services';
-import { AVAILABLE_BUCKETS, ALLOWED_UPLOAD_TYPES, DEFAULT_BUCKET } from '../../config';
-import { IStoreParams, IStoreFileParams } from '../../types';
-import { isValidUUID } from '../../utils';
-import { ApiError, ApplicationError, BadRequestError, ConflictError } from '../../errors';
-import { apiLogger as logger } from '../../services/logging';
+import { IStorageService, ICryptographyService } from '../../../services';
+import { AVAILABLE_BUCKETS, ALLOWED_UPLOAD_TYPES, DEFAULT_BUCKET } from '../../../config';
+import { IStoreParams, IStoreFileParams } from '../../../types';
+import { isValidUUID } from '../../../utils';
+import { ApiError, ApplicationError, BadRequestError, ConflictError } from '../../../errors';
+import { apiLogger as logger } from '../../../services/logging';
 
 export class PrivateService {
     /**

--- a/src/routes/v4/public/controller.test.ts
+++ b/src/routes/v4/public/controller.test.ts
@@ -1,3 +1,4 @@
+import fs from 'fs';
 import os from 'os';
 import path from 'path';
 import { getMockReq, getMockRes } from '@jest-mock/express';
@@ -21,86 +22,77 @@ jest.mock('../../services/logging', () => ({
     serverLogger: mockLogger,
 }));
 
-import { BadRequestError } from '../../errors';
-import { PrivateService } from './service';
+import { storePublic } from './controller';
+import { PublicService } from './service';
+import { BadRequestError } from '../../../errors';
 
 const { res: mockRes, next: mockNext, clearMockRes } = getMockRes();
 
-jest.mock('../../config', () => ({
+jest.mock('../../../config', () => ({
     AVAILABLE_BUCKETS: ['bucketName'],
     STORAGE_TYPE: 'gcp',
 }));
 
-jest.mock('../../services/cryptography', () => ({
-    CryptographyService: jest.fn().mockImplementation(() => ({
-        computeDigestMultibase: jest.fn().mockResolvedValue('mocked-digest'),
-        generateEncryptionKey: jest.fn().mockResolvedValue('test-encryption-key'),
-        encryptString: jest
-            .fn()
-            .mockReturnValue({ cipherText: 'encrypted', iv: 'test-iv', tag: 'test-tag', type: 'aes-256-gcm' }),
-    })),
-}));
-
-jest.mock('../../services/storage/gcp', () => ({
+jest.mock('../../../services/storage/gcp', () => ({
     GCPStorageService: jest.fn().mockImplementation(() => ({
         uploadFile: jest.fn().mockResolvedValue({ uri: 'mock-uri' }),
         objectExists: jest.fn().mockResolvedValue(false),
     })),
 }));
 
+jest.mock('../../../services/cryptography', () => ({
+    CryptographyService: jest.fn().mockImplementation(() => ({
+        computeDigestMultibase: jest.fn().mockResolvedValue('mocked-digest'),
+    })),
+}));
+
 jest.mock('fs', () => ({
     ...jest.requireActual('fs'),
     promises: {
-        readFile: jest.fn().mockResolvedValue(Buffer.from('binary-content')),
+        readFile: jest.fn().mockResolvedValue(Buffer.from('fake-binary-content')),
         unlink: jest.fn().mockResolvedValue(undefined),
     },
 }));
 
-import fs from 'fs';
-import { storePrivate } from './controller';
-
-describe('Private Controller', () => {
+describe('PublicController', () => {
     beforeEach(() => {
         clearMockRes();
         jest.clearAllMocks();
     });
 
-    describe('storePrivate', () => {
-        it('should successfully store a JSON document and return 201', async () => {
-            const spy = jest.spyOn(PrivateService.prototype, 'encryptAndStoreDocument').mockResolvedValue({
+    describe('storePublic', () => {
+        it('should successfully store a JSON document and return 201 with uri and digestMultibase', async () => {
+            const storeDocumentSpy = jest.spyOn(PublicService.prototype, 'storeDocument').mockResolvedValue({
                 uri: 'mock-uri',
                 digestMultibase: 'mocked-digest',
-                decryptionKey: 'test-encryption-key',
             });
 
             const mockReq = getMockReq({
                 body: {
                     bucket: 'bucketName',
-                    id: '550e8400-e29b-41d4-a716-446655440000',
-                    data: { key: 'value' },
+                    id: '123e4567-e89b-12d3-a456-426614174000',
+                    data: { name: 'test' },
                 },
             });
 
-            await storePrivate(mockReq, mockRes, mockNext);
+            await storePublic(mockReq, mockRes, mockNext);
 
             expect(mockRes.status).toHaveBeenCalledWith(201);
             expect(mockRes.json).toHaveBeenCalledWith({
                 uri: 'mock-uri',
                 digestMultibase: 'mocked-digest',
-                decryptionKey: 'test-encryption-key',
             });
-            expect(spy).toHaveBeenCalledWith(
+            expect(storeDocumentSpy).toHaveBeenCalledWith(
                 expect.anything(), // storageService
-                expect.anything(), // cryptographyService
-                { bucket: 'bucketName', id: '550e8400-e29b-41d4-a716-446655440000', data: { key: 'value' } },
+                expect.anything(), // cryptoService
+                { bucket: 'bucketName', id: '123e4567-e89b-12d3-a456-426614174000', data: { name: 'test' } },
             );
         });
 
-        it('should successfully store a binary file and return 201', async () => {
-            const spy = jest.spyOn(PrivateService.prototype, 'encryptAndStoreFile').mockResolvedValue({
-                uri: 'mock-uri',
-                digestMultibase: 'mocked-digest',
-                decryptionKey: 'test-encryption-key',
+        it('should successfully store a binary file and return 201 with uri and digestMultibase', async () => {
+            const storeFileSpy = jest.spyOn(PublicService.prototype, 'storeFile').mockResolvedValue({
+                uri: 'mock-file-uri',
+                digestMultibase: 'mocked-file-digest',
             });
 
             const tempFilePath = path.join(os.tmpdir(), 'upload-12345');
@@ -108,28 +100,27 @@ describe('Private Controller', () => {
                 file: {
                     path: tempFilePath,
                     mimetype: 'image/png',
-                } as any,
+                } as Express.Multer.File,
                 body: {
                     bucket: 'bucketName',
-                    id: '550e8400-e29b-41d4-a716-446655440000',
+                    id: '123e4567-e89b-12d3-a456-426614174000',
                 },
             });
 
-            await storePrivate(mockReq, mockRes, mockNext);
+            await storePublic(mockReq, mockRes, mockNext);
 
             expect(fs.promises.readFile).toHaveBeenCalledWith(path.resolve(tempFilePath));
             expect(mockRes.status).toHaveBeenCalledWith(201);
             expect(mockRes.json).toHaveBeenCalledWith({
-                uri: 'mock-uri',
-                digestMultibase: 'mocked-digest',
-                decryptionKey: 'test-encryption-key',
+                uri: 'mock-file-uri',
+                digestMultibase: 'mocked-file-digest',
             });
-            expect(spy).toHaveBeenCalledWith(
-                expect.anything(),
-                expect.anything(),
+            expect(storeFileSpy).toHaveBeenCalledWith(
+                expect.anything(), // storageService
+                expect.anything(), // cryptoService
                 expect.objectContaining({
                     bucket: 'bucketName',
-                    id: '550e8400-e29b-41d4-a716-446655440000',
+                    id: '123e4567-e89b-12d3-a456-426614174000',
                     file: expect.any(Buffer),
                     mimeType: 'image/png',
                 }),
@@ -137,18 +128,18 @@ describe('Private Controller', () => {
         });
 
         it('should return 400 for an invalid bucket', async () => {
-            jest.spyOn(PrivateService.prototype, 'encryptAndStoreDocument').mockRejectedValue(
+            jest.spyOn(PublicService.prototype, 'storeDocument').mockRejectedValue(
                 new BadRequestError('Invalid bucket. Must be one of the following buckets: bucketName'),
             );
 
             const mockReq = getMockReq({
                 body: {
-                    bucket: 'invalidBucket',
-                    data: { key: 'value' },
+                    bucket: 'invalid-bucket',
+                    data: { name: 'test' },
                 },
             });
 
-            await storePrivate(mockReq, mockRes, mockNext);
+            await storePublic(mockReq, mockRes, mockNext);
 
             expect(mockRes.status).toHaveBeenCalledWith(400);
             expect(mockRes.json).toHaveBeenCalledWith({
@@ -156,23 +147,23 @@ describe('Private Controller', () => {
             });
         });
 
-        it('should return 500 when a non-ApiError is thrown', async () => {
-            jest.spyOn(PrivateService.prototype, 'encryptAndStoreDocument').mockRejectedValue(
+        it('should return 500 for unexpected errors', async () => {
+            jest.spyOn(PublicService.prototype, 'storeDocument').mockRejectedValue(
                 new Error('Something went terribly wrong'),
             );
 
             const mockReq = getMockReq({
                 body: {
                     bucket: 'bucketName',
-                    data: { key: 'value' },
+                    data: { name: 'test' },
                 },
             });
 
-            await storePrivate(mockReq, mockRes, mockNext);
+            await storePublic(mockReq, mockRes, mockNext);
 
             expect(mockRes.status).toHaveBeenCalledWith(500);
             expect(mockRes.json).toHaveBeenCalledWith({
-                message: 'An unexpected error occurred while storing private data.',
+                message: 'An unexpected error occurred while storing the resource.',
             });
         });
 
@@ -180,7 +171,7 @@ describe('Private Controller', () => {
             const mockReq = getMockReq({
                 body: {
                     bucket: 'bucketName',
-                    id: '550e8400-e29b-41d4-a716-446655440000',
+                    id: '123e4567-e89b-12d3-a456-426614174000',
                 },
             });
             mockReq.is = jest.fn((type: string) =>
@@ -188,7 +179,7 @@ describe('Private Controller', () => {
             ) as any;
             mockReq.file = undefined;
 
-            await storePrivate(mockReq, mockRes, mockNext);
+            await storePublic(mockReq, mockRes, mockNext);
 
             expect(mockRes.status).toHaveBeenCalledWith(400);
             expect(mockRes.json).toHaveBeenCalledWith({
@@ -197,45 +188,41 @@ describe('Private Controller', () => {
         });
 
         it('should clean up the temporary file after a binary upload', async () => {
-            jest.spyOn(PrivateService.prototype, 'encryptAndStoreFile').mockResolvedValue({
-                uri: 'mock-uri',
-                digestMultibase: 'mocked-digest',
-                decryptionKey: 'test-encryption-key',
+            jest.spyOn(PublicService.prototype, 'storeFile').mockResolvedValue({
+                uri: 'mock-file-uri',
+                digestMultibase: 'mocked-file-digest',
             });
 
-            const tempPath = path.join(os.tmpdir(), 'upload-cleanup-test');
+            const tempFilePath = path.join(os.tmpdir(), 'upload-cleanup-test');
             const mockReq = getMockReq({
                 file: {
-                    path: tempPath,
+                    path: tempFilePath,
                     mimetype: 'image/png',
-                } as any,
+                } as Express.Multer.File,
                 body: {
                     bucket: 'bucketName',
-                    id: '550e8400-e29b-41d4-a716-446655440000',
                 },
             });
 
-            await storePrivate(mockReq, mockRes, mockNext);
+            await storePublic(mockReq, mockRes, mockNext);
 
-            expect(fs.promises.unlink).toHaveBeenCalledWith(path.resolve(tempPath));
+            expect(fs.promises.unlink).toHaveBeenCalledWith(path.resolve(tempFilePath));
         });
-
         it('should not attempt to clean up when there is no temporary file', async () => {
-            jest.spyOn(PrivateService.prototype, 'encryptAndStoreDocument').mockResolvedValue({
+            jest.spyOn(PublicService.prototype, 'storeDocument').mockResolvedValue({
                 uri: 'mock-uri',
                 digestMultibase: 'mocked-digest',
-                decryptionKey: 'test-encryption-key',
             });
 
             const mockReq = getMockReq({
                 body: {
                     bucket: 'bucketName',
-                    id: '550e8400-e29b-41d4-a716-446655440000',
-                    data: { key: 'value' },
+                    id: '123e4567-e89b-12d3-a456-426614174000',
+                    data: { name: 'test' },
                 },
             });
 
-            await storePrivate(mockReq, mockRes, mockNext);
+            await storePublic(mockReq, mockRes, mockNext);
 
             expect(fs.promises.unlink).not.toHaveBeenCalled();
         });
@@ -248,13 +235,13 @@ describe('Private Controller', () => {
                 file: {
                     path: tempPath,
                     mimetype: 'image/png',
-                } as any,
+                } as Express.Multer.File,
                 body: {
                     bucket: 'bucketName',
                 },
             });
 
-            await storePrivate(mockReq, mockRes, mockNext);
+            await storePublic(mockReq, mockRes, mockNext);
 
             expect(fs.promises.unlink).toHaveBeenCalledWith(path.resolve(tempPath));
         });
@@ -264,10 +251,9 @@ describe('Private Controller', () => {
                 Object.assign(new Error('EACCES: permission denied'), { code: 'EACCES' }),
             );
 
-            jest.spyOn(PrivateService.prototype, 'encryptAndStoreFile').mockResolvedValue({
+            jest.spyOn(PublicService.prototype, 'storeFile').mockResolvedValue({
                 uri: 'mock-uri',
                 digestMultibase: 'mocked-digest',
-                decryptionKey: 'test-encryption-key',
             });
 
             const tempPath = path.join(os.tmpdir(), 'upload-unlink-error');
@@ -276,7 +262,7 @@ describe('Private Controller', () => {
                 body: { bucket: 'bucketName', id: '550e8400-e29b-41d4-a716-446655440000' },
             });
 
-            await storePrivate(mockReq, mockRes, mockNext);
+            await storePublic(mockReq, mockRes, mockNext);
 
             expect(fs.promises.unlink).toHaveBeenCalledWith(path.resolve(tempPath));
             expect(mockLogger.error).toHaveBeenCalledWith(
@@ -290,14 +276,14 @@ describe('Private Controller', () => {
                 file: {
                     path: '/etc/passwd',
                     mimetype: 'application/octet-stream',
-                } as any,
+                } as Express.Multer.File,
                 body: {
                     bucket: 'bucketName',
-                    id: '550e8400-e29b-41d4-a716-446655440000',
+                    id: '123e4567-e89b-12d3-a456-426614174000',
                 },
             });
 
-            await storePrivate(mockReq, mockRes, mockNext);
+            await storePublic(mockReq, mockRes, mockNext);
 
             expect(mockRes.status).toHaveBeenCalledWith(400);
             expect(mockRes.json).toHaveBeenCalledWith({

--- a/src/routes/v4/public/controller.test.ts
+++ b/src/routes/v4/public/controller.test.ts
@@ -12,7 +12,7 @@ const mockLogger: any = {
 };
 mockLogger.child = jest.fn(() => mockLogger);
 
-jest.mock('../../services/logging', () => ({
+jest.mock('../../../services/logging', () => ({
     getLogger: () => mockLogger,
     apiLogger: mockLogger,
     authLogger: mockLogger,

--- a/src/routes/v4/public/controller.ts
+++ b/src/routes/v4/public/controller.ts
@@ -2,35 +2,35 @@ import fs from 'fs';
 import path from 'path';
 import os from 'os';
 import { RequestHandler } from 'express';
-import { CryptographyService, IStorageService, initialiseStorageService } from '../../services';
-import { ApiError, BadRequestError } from '../../errors';
-import { PrivateService } from './service';
-import { apiLogger } from '../../services/logging';
+import { initialiseStorageService, CryptographyService, IStorageService } from '../../../services';
+import { PublicService } from './service';
+import { ApiError, BadRequestError } from '../../../errors';
+import { apiLogger } from '../../../services/logging';
 
-const logger = apiLogger.child({ route: 'POST /private' });
+const logger = apiLogger.child({ route: 'POST /public' });
 const UPLOAD_DIR = path.resolve(os.tmpdir());
 
 /**
- * Handles the request to store private data (JSON or binary) with encryption.
+ * Handles the request to store a public document or file.
  *
- * For binary uploads (multipart/form-data), the file is read from the temporary
- * path, encrypted, and stored. The temporary file is cleaned up in a finally block.
+ * For multipart/form-data requests (binary uploads), reads the uploaded file
+ * from the temporary path, stores it via PublicService.storeFile(), and cleans
+ * up the temporary file afterwards.
  *
- * For JSON uploads, the body parameters are passed directly to the service for
- * encryption and storage.
+ * For JSON requests, extracts parameters from the request body and stores the
+ * document via PublicService.storeDocument().
  *
- * @param req The request object containing either a file upload or JSON body.
+ * @param req The request object.
  * @param res The response object.
- * @returns A JSON response with the stored item's URI, multibase digest, and decryption key on success,
- *          or an error message with an appropriate status code on failure.
+ * @returns The response with the stored URI and multibase digest.
  */
-export const storePrivate: RequestHandler = async (req, res) => {
+export const storePublic: RequestHandler = async (req, res) => {
     let tempPath: string | undefined;
 
     try {
-        const privateService = new PrivateService();
+        const publicService = new PublicService();
         const storageService: IStorageService = initialiseStorageService();
-        const cryptographyService = new CryptographyService();
+        const cryptoService = new CryptographyService();
 
         let response;
 
@@ -42,7 +42,7 @@ export const storePrivate: RequestHandler = async (req, res) => {
             tempPath = resolvedPath;
             const fileBuffer = await fs.promises.readFile(tempPath);
 
-            response = await privateService.encryptAndStoreFile(storageService, cryptographyService, {
+            response = await publicService.storeFile(storageService, cryptoService, {
                 bucket: req.body.bucket,
                 id: req.body.id,
                 file: fileBuffer,
@@ -53,19 +53,19 @@ export const storePrivate: RequestHandler = async (req, res) => {
         } else {
             const params = req.body;
 
-            response = await privateService.encryptAndStoreDocument(storageService, cryptographyService, params);
+            response = await publicService.storeDocument(storageService, cryptoService, params);
         }
 
         res.status(201).json(response);
     } catch (err: any) {
-        logger.error({ err }, '[PrivateController.storePrivate] An error occurred while storing private data');
+        logger.error({ err }, '[PublicController.storePublic] An error occurred while storing the resource');
 
         if (err instanceof ApiError) {
             return res.status(err.statusCode).json({ message: err.message });
         }
 
         res.status(500).json({
-            message: 'An unexpected error occurred while storing private data.',
+            message: 'An unexpected error occurred while storing the resource.',
         });
     } finally {
         if (tempPath && tempPath.startsWith(UPLOAD_DIR + path.sep)) {
@@ -75,7 +75,7 @@ export const storePrivate: RequestHandler = async (req, res) => {
                 if (cleanupErr.code !== 'ENOENT') {
                     logger.error(
                         { tempPath, err: cleanupErr },
-                        '[PrivateController.storePrivate] Failed to clean up temp file',
+                        '[PublicController.storePublic] Failed to clean up temp file',
                     );
                 }
             }

--- a/src/routes/v4/public/index.ts
+++ b/src/routes/v4/public/index.ts
@@ -1,7 +1,7 @@
 import { Router } from 'express';
 import { storePublic } from './controller';
-import { authenticateRequest } from '../../middleware/authentication';
-import { conditionalUpload, handleUploadError } from '../../middleware/upload';
+import { authenticateRequest } from '../../../middleware/authentication';
+import { conditionalUpload, handleUploadError } from '../../../middleware/upload';
 
 export const publicRouter = Router();
 

--- a/src/routes/v4/public/service.test.ts
+++ b/src/routes/v4/public/service.test.ts
@@ -1,9 +1,9 @@
-import { IStorageService, ICryptographyService } from '../../services';
+import { IStorageService, ICryptographyService } from '../../../services';
 import { PublicService } from './service';
 import { v4 } from 'uuid';
-import { BadRequestError, ConflictError, ApplicationError } from '../../errors';
+import { BadRequestError, ConflictError, ApplicationError } from '../../../errors';
 
-jest.mock('../../config', () => ({
+jest.mock('../../../config', () => ({
     AVAILABLE_BUCKETS: ['my-bucket'],
     ALLOWED_UPLOAD_TYPES: ['image/png', 'image/jpeg', 'application/pdf'],
     DEFAULT_BUCKET: undefined,
@@ -212,7 +212,7 @@ describe('PublicService', () => {
         });
 
         it('should use DEFAULT_BUCKET when bucket is not provided', async () => {
-            const configModule = require('../../config');
+            const configModule = require('../../../config');
             configModule.DEFAULT_BUCKET = 'my-bucket';
 
             try {
@@ -234,7 +234,7 @@ describe('PublicService', () => {
         });
 
         it('should use DEFAULT_BUCKET when bucket is an empty string', async () => {
-            const configModule = require('../../config');
+            const configModule = require('../../../config');
             configModule.DEFAULT_BUCKET = 'my-bucket';
 
             try {
@@ -256,7 +256,7 @@ describe('PublicService', () => {
         });
 
         it('should prefer explicit bucket over DEFAULT_BUCKET', async () => {
-            const configModule = require('../../config');
+            const configModule = require('../../../config');
             configModule.DEFAULT_BUCKET = 'other-bucket';
 
             try {
@@ -534,7 +534,7 @@ describe('PublicService', () => {
         });
 
         it('should use DEFAULT_BUCKET when bucket is not provided', async () => {
-            const configModule = require('../../config');
+            const configModule = require('../../../config');
             configModule.DEFAULT_BUCKET = 'my-bucket';
 
             try {
@@ -556,7 +556,7 @@ describe('PublicService', () => {
         });
 
         it('should use DEFAULT_BUCKET when bucket is an empty string', async () => {
-            const configModule = require('../../config');
+            const configModule = require('../../../config');
             configModule.DEFAULT_BUCKET = 'my-bucket';
 
             try {
@@ -578,7 +578,7 @@ describe('PublicService', () => {
         });
 
         it('should prefer explicit bucket over DEFAULT_BUCKET', async () => {
-            const configModule = require('../../config');
+            const configModule = require('../../../config');
             configModule.DEFAULT_BUCKET = 'other-bucket';
 
             try {

--- a/src/routes/v4/public/service.ts
+++ b/src/routes/v4/public/service.ts
@@ -1,12 +1,12 @@
 import { isPlainObject } from 'lodash';
 import { v4 } from 'uuid';
 import { extension } from 'mime-types';
-import { IStorageService, ICryptographyService } from '../../services';
-import { ApiError, ApplicationError, BadRequestError, ConflictError } from '../../errors';
-import { AVAILABLE_BUCKETS, ALLOWED_UPLOAD_TYPES, DEFAULT_BUCKET } from '../../config';
-import { isValidUUID } from '../../utils';
-import { IStoreParams, IStoreFileParams } from '../../types';
-import { apiLogger as logger } from '../../services/logging';
+import { IStorageService, ICryptographyService } from '../../../services';
+import { ApiError, ApplicationError, BadRequestError, ConflictError } from '../../../errors';
+import { AVAILABLE_BUCKETS, ALLOWED_UPLOAD_TYPES, DEFAULT_BUCKET } from '../../../config';
+import { isValidUUID } from '../../../utils';
+import { IStoreParams, IStoreFileParams } from '../../../types';
+import { apiLogger as logger } from '../../../services/logging';
 
 export class PublicService {
     /**

--- a/src/server.ts
+++ b/src/server.ts
@@ -1,5 +1,5 @@
 import { app } from './app';
-import { API_VERSION, DOMAIN, EXTERNAL_PORT, MAX_UPLOAD_SIZE, PORT, PROTOCOL, getApiKey } from './config';
+import { DOMAIN, EXTERNAL_PORT, MAX_UPLOAD_SIZE, PORT, PROTOCOL, getApiKey } from './config';
 import { buildBaseUrl } from './utils';
 import { serverLogger as logger } from './services/logging';
 
@@ -29,5 +29,5 @@ if (isNaN(MAX_UPLOAD_SIZE) || MAX_UPLOAD_SIZE <= 0) {
 
 app.listen(PORT, () => {
     const base = buildBaseUrl(PROTOCOL, DOMAIN, EXTERNAL_PORT);
-    logger.info({ url: `${base}/api/${API_VERSION}`, docsUrl: `${base}/api-docs` }, 'Server started');
+    logger.info({ url: `${base}/api/v4`, docsUrl: `${base}/api-docs` }, 'Server started');
 });

--- a/src/services/storage/local.test.ts
+++ b/src/services/storage/local.test.ts
@@ -1,18 +1,12 @@
 import { LocalStorageService } from './local';
 
-const { apiVersion: API_VERSION } = require('../../../version.json');
-
-jest.mock('../../config', () => {
-    const { apiVersion } = require('../../../version.json');
-    return {
-        API_VERSION: apiVersion,
-        DOMAIN: 'localhost',
-        LOCAL_DIRECTORY: 'uploads',
-        PORT: '3333',
-        EXTERNAL_PORT: '3333',
-        PROTOCOL: 'http',
-    };
-});
+jest.mock('../../config', () => ({
+    DOMAIN: 'localhost',
+    LOCAL_DIRECTORY: 'uploads',
+    PORT: '3333',
+    EXTERNAL_PORT: '3333',
+    PROTOCOL: 'http',
+}));
 
 jest.mock('fs', () => {
     const actual = jest.createMockFromModule<typeof import('fs')>('fs');
@@ -41,7 +35,7 @@ describe('LocalStorageService', () => {
 
         const result = await storageService.uploadFile(bucket, key, body, contentType);
 
-        expect(result.uri).toEqual(`http://localhost:3333/api/${API_VERSION}/test-bucket/test-file.json`);
+        expect(result.uri).toEqual(`http://localhost:3333/api/v4/test-bucket/test-file.json`);
     });
 
     it('should upload a Buffer body to the local file system', async () => {
@@ -52,7 +46,7 @@ describe('LocalStorageService', () => {
 
         const result = await storageService.uploadFile(bucket, key, body, contentType);
 
-        expect(result.uri).toEqual(`http://localhost:3333/api/${API_VERSION}/test-bucket/test-file.bin`);
+        expect(result.uri).toEqual(`http://localhost:3333/api/v4/test-bucket/test-file.bin`);
     });
 
     it('should use key as-passed in objectExists without appending .json', () => {

--- a/src/services/storage/local.ts
+++ b/src/services/storage/local.ts
@@ -1,7 +1,7 @@
 import fs from 'fs';
 import path from 'path';
 import { IStorageService } from '.';
-import { API_VERSION, DOMAIN, EXTERNAL_PORT, LOCAL_DIRECTORY, PROTOCOL, __dirname } from '../../config';
+import { DOMAIN, EXTERNAL_PORT, LOCAL_DIRECTORY, PROTOCOL, __dirname } from '../../config';
 import { buildBaseUrl } from '../../utils';
 
 /**
@@ -28,7 +28,7 @@ export class LocalStorageService implements IStorageService {
 
         // Write data to file
         fs.writeFileSync(filePath, body);
-        return { uri: buildBaseUrl(PROTOCOL, DOMAIN, EXTERNAL_PORT, `api/${API_VERSION}/${bucket}/${key}`) };
+        return { uri: buildBaseUrl(PROTOCOL, DOMAIN, EXTERNAL_PORT, `api/v4/${bucket}/${key}`) };
     }
 
     /**

--- a/src/swagger/paths.json
+++ b/src/swagger/paths.json
@@ -37,7 +37,7 @@
                                         "uri": {
                                             "type": "string",
                                             "description": "The location where your data is stored.",
-                                            "example": "http://localhost:3333/api/3.0.0/documents/123e4567-e89b-12d3-a456-426614174000.json"
+                                            "example": "http://localhost:3333/api/v4/documents/123e4567-e89b-12d3-a456-426614174000.json"
                                         },
                                         "digestMultibase": {
                                             "type": "string",
@@ -117,7 +117,7 @@
                                         "uri": {
                                             "type": "string",
                                             "description": "The location where your encrypted data is stored.",
-                                            "example": "http://localhost:3333/api/3.0.0/documents/123e4567-e89b-12d3-a456-426614174000.json"
+                                            "example": "http://localhost:3333/api/v4/documents/123e4567-e89b-12d3-a456-426614174000.json"
                                         },
                                         "digestMultibase": {
                                             "type": "string",

--- a/src/swagger/swagger-url.test.ts
+++ b/src/swagger/swagger-url.test.ts
@@ -1,9 +1,6 @@
 import request from 'supertest';
 
-const { apiVersion: API_VERSION } = require('../../version.json');
-
 const buildConfigMock = (overrides: Record<string, unknown> = {}) => ({
-    API_VERSION: API_VERSION,
     PROTOCOL: overrides.PROTOCOL ?? 'http',
     DOMAIN: overrides.DOMAIN ?? 'localhost',
     PORT: overrides.PORT ?? 3333,
@@ -34,14 +31,14 @@ describe('Swagger URL Tests', () => {
         it('should omit port 443 for HTTPS', async () => {
             const response = await getSwaggerInitResponse({ PROTOCOL: 'https', DOMAIN: 'api.example.com', PORT: 443 });
 
-            expect(response.text).toContain(`"url": "https://api.example.com/api/${API_VERSION}"`);
+            expect(response.text).toContain(`"url": "https://api.example.com/api/v4"`);
             expect(response.text).not.toContain('"url": "https://api.example.com:443');
         });
 
         it('should omit port 80 for HTTP', async () => {
             const response = await getSwaggerInitResponse({ PROTOCOL: 'http', DOMAIN: 'example.com', PORT: 80 });
 
-            expect(response.text).toContain(`"url": "http://example.com/api/${API_VERSION}"`);
+            expect(response.text).toContain(`"url": "http://example.com/api/v4"`);
             expect(response.text).not.toContain('"url": "http://example.com:80');
         });
     });
@@ -50,19 +47,19 @@ describe('Swagger URL Tests', () => {
         it('should include port for HTTP on non-standard port', async () => {
             const response = await getSwaggerInitResponse({ PROTOCOL: 'http', DOMAIN: 'localhost', PORT: 3333 });
 
-            expect(response.text).toContain(`"url": "http://localhost:3333/api/${API_VERSION}"`);
+            expect(response.text).toContain(`"url": "http://localhost:3333/api/v4"`);
         });
 
         it('should include port for HTTPS on non-standard port', async () => {
             const response = await getSwaggerInitResponse({ PROTOCOL: 'https', DOMAIN: 'api.example.com', PORT: 8443 });
 
-            expect(response.text).toContain(`"url": "https://api.example.com:8443/api/${API_VERSION}"`);
+            expect(response.text).toContain(`"url": "https://api.example.com:8443/api/v4"`);
         });
 
         it('should include custom port for HTTP', async () => {
             const response = await getSwaggerInitResponse({ PROTOCOL: 'http', DOMAIN: 'dev.example.com', PORT: 8080 });
 
-            expect(response.text).toContain(`"url": "http://dev.example.com:8080/api/${API_VERSION}"`);
+            expect(response.text).toContain(`"url": "http://dev.example.com:8080/api/v4"`);
         });
     });
 
@@ -74,7 +71,7 @@ describe('Swagger URL Tests', () => {
                 PORT: '443',
             });
 
-            expect(response.text).toContain(`"url": "https://api.example.com/api/${API_VERSION}"`);
+            expect(response.text).toContain(`"url": "https://api.example.com/api/v4"`);
             expect(response.text).not.toContain('"url": "https://api.example.com:443');
         });
     });
@@ -83,7 +80,7 @@ describe('Swagger URL Tests', () => {
         it('should use EXTERNAL_PORT instead of PORT for Swagger URL', async () => {
             const response = await getSwaggerInitResponse({ PORT: 3333, EXTERNAL_PORT: 8080 });
 
-            expect(response.text).toContain(`"url": "http://localhost:8080/api/${API_VERSION}"`);
+            expect(response.text).toContain(`"url": "http://localhost:8080/api/v4"`);
             expect(response.text).not.toContain('"url": "http://localhost:3333');
         });
 
@@ -95,7 +92,7 @@ describe('Swagger URL Tests', () => {
                 EXTERNAL_PORT: 443,
             });
 
-            expect(response.text).toContain(`"url": "https://api.example.com/api/${API_VERSION}"`);
+            expect(response.text).toContain(`"url": "https://api.example.com/api/v4"`);
             expect(response.text).not.toContain('"url": "https://api.example.com:443');
             expect(response.text).not.toContain('"url": "https://api.example.com:3333');
         });
@@ -108,7 +105,7 @@ describe('Swagger URL Tests', () => {
                 EXTERNAL_PORT: 80,
             });
 
-            expect(response.text).toContain(`"url": "http://example.com/api/${API_VERSION}"`);
+            expect(response.text).toContain(`"url": "http://example.com/api/v4"`);
             expect(response.text).not.toContain('"url": "http://example.com:80');
             expect(response.text).not.toContain('"url": "http://example.com:3333');
         });
@@ -116,7 +113,7 @@ describe('Swagger URL Tests', () => {
         it('should fall back to PORT when EXTERNAL_PORT is not set', async () => {
             const response = await getSwaggerInitResponse({ PORT: 9090 });
 
-            expect(response.text).toContain(`"url": "http://localhost:9090/api/${API_VERSION}"`);
+            expect(response.text).toContain(`"url": "http://localhost:9090/api/v4"`);
         });
     });
 });

--- a/src/swagger/swagger.json
+++ b/src/swagger/swagger.json
@@ -47,7 +47,7 @@
                     "uri": {
                       "type": "string",
                       "description": "The location where your data is stored.",
-                      "example": "http://localhost:3333/api/3.0.0/documents/123e4567-e89b-12d3-a456-426614174000.json"
+                      "example": "http://localhost:3333/api/v4/documents/123e4567-e89b-12d3-a456-426614174000.json"
                     },
                     "digestMultibase": {
                       "type": "string",
@@ -127,7 +127,7 @@
                     "uri": {
                       "type": "string",
                       "description": "The location where your encrypted data is stored.",
-                      "example": "http://localhost:3333/api/3.0.0/documents/123e4567-e89b-12d3-a456-426614174000.json"
+                      "example": "http://localhost:3333/api/v4/documents/123e4567-e89b-12d3-a456-426614174000.json"
                     },
                     "digestMultibase": {
                       "type": "string",

--- a/version.json
+++ b/version.json
@@ -1,5 +1,6 @@
 {
     "version": "3.2.1",
+    "apiVersion": "4.0",
     "docVersion": "3.2.0",
     "dependencies": {}
 }

--- a/version.json
+++ b/version.json
@@ -1,6 +1,5 @@
 {
     "version": "3.2.1",
-    "apiVersion": "3.1.0",
     "docVersion": "3.2.0",
     "dependencies": {}
 }


### PR DESCRIPTION
This PR switches the API URL path segment from full SemVer (`/api/3.1.0/...`) to major-only (`/api/v4/...`). Route handlers move from `src/routes/{public,private,delete}/` to `src/routes/v4/{...}`; the directory name carries the version literal and references to `v4` are hardcoded at each callsite rather than threaded through an indirection layer.

`apiVersion` is removed from `version.json` and `getApiVersion()` / `API_VERSION` are removed from `src/config.ts`. A `migrating-to-4.md` guide covers this change alongside the previous `hash` → `digestMultibase` cutover (#111), since both ship together in 4.0.0. Release-process docs and `RELEASE_MANAGEMENT_GUIDE.md` drop their stale `apiVersion` references.

The `version` and `package.json` fields stay at `3.2.x` in this PR; release-please bumps the major to `4.0.0` automatically when it sees the `feat!:` markers from this PR and #111 in the next release run.

Closes #114

## Test plan
- [x] Unit + integration tests pass (224 across 18 suites)
- [x] New `src/app.routing.test.ts` mounts the real Express app via supertest and asserts: `/api/v4/{public,private,:bucket/:id}` resolve, legacy `/api/3.x.x/...` and `/api/v3/...` return 404, static files served at `/api/v4/<bucket>/<key>` only, `/health-check` stays at the top level
- [x] Webpack production build succeeds
- [x] Lint clean on changed files
- [ ] Full docker e2e suite (\`yarn test:e2e\`) deferred to CI