### PR TITLE
feat(logging): structured Pino logging with correlation-ID propagation

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,6 +132,19 @@ Configure the storage service using the following environment variables:
 - `ALLOWED_UPLOAD_TYPES`:
   Comma-separated list of permitted MIME types (default: `image/png,image/jpeg,image/webp,application/pdf`).
 
+### Logging
+
+The service emits structured JSON logs via Pino. Every log line includes a `correlationId` matching the request that produced it.
+
+- `LOG_LEVEL`:
+  Minimum level emitted: `debug`, `info`, `warn`, or `error` (default: `info`).
+- `LOG_PRETTY`:
+  Set to `true` to format logs for human reading (uses `pino-pretty`). Off by default; production should leave this unset so logs stay structured JSON for ingestion by log pipelines.
+
+### Correlation IDs
+
+Every response carries an `x-correlation-id` header. Inbound `x-correlation-id` request headers are accepted and propagated when they pass validation (max 128 characters, charset `[A-Za-z0-9_-]`); invalid or missing values are replaced by a freshly minted UUID. Use this to trace a single logical request across services.
+
 ### S3-Compatible Storage (AWS, MinIO, DigitalOcean Spaces, Cloudflare R2, etc.)
 
 - `S3_REGION`:

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
         "mime-types": "^3.0.2",
         "multer": "^2.0.2",
         "pino": "^10.3.1",
+        "pino-pretty": "^13.1.3",
         "swagger-ui-express": "^5.0.1",
         "uuid": "^10.0.0"
     },
@@ -61,7 +62,6 @@
         "lint-staged": "^16.2.7",
         "nodemon": "^3.0.3",
         "npm-run-all": "^4.1.5",
-        "pino-pretty": "^13.1.3",
         "prettier": "^3.2.5",
         "supertest": "^7.1.4",
         "terser-webpack-plugin": "^5.3.10",

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
         "lodash": "^4.17.21",
         "mime-types": "^3.0.2",
         "multer": "^2.0.2",
+        "pino": "^10.3.1",
         "swagger-ui-express": "^5.0.1",
         "uuid": "^10.0.0"
     },
@@ -60,6 +61,7 @@
         "lint-staged": "^16.2.7",
         "nodemon": "^3.0.3",
         "npm-run-all": "^4.1.5",
+        "pino-pretty": "^13.1.3",
         "prettier": "^3.2.5",
         "supertest": "^7.1.4",
         "terser-webpack-plugin": "^5.3.10",

--- a/src/app.ts
+++ b/src/app.ts
@@ -7,8 +7,16 @@ import swaggerDocument from './swagger/swagger.json';
 import { updateSwagger } from './swagger/helpers';
 import { API_VERSION, DOMAIN, EXTERNAL_PORT, MAX_UPLOAD_SIZE, PROTOCOL } from './config';
 import { buildBaseUrl } from './utils';
+import { getLogger } from './services/logging';
+import { correlationIdMiddleware } from './middleware/correlation-id';
+
+const logger = getLogger();
 
 export const app = express();
+
+// Correlation ID middleware runs FIRST so every downstream handler and every
+// log line (via the registered request-context provider) carries the id.
+app.use(correlationIdMiddleware(logger));
 
 let swaggerJson: any = { ...swaggerDocument };
 
@@ -39,7 +47,10 @@ app.use(`/api/${API_VERSION}`, router);
 
 // Global error handler for unhandled errors
 app.use((err: any, _req: Request, res: Response, _next: NextFunction) => {
-    console.error('[GlobalErrorHandler] Unhandled error:', err);
+    logger.error(
+        { err: err instanceof Error ? { message: err.message, stack: err.stack } : err },
+        '[GlobalErrorHandler] Unhandled error',
+    );
     res.status(500).json({
         message: 'An unexpected error occurred.',
     });

--- a/src/app.ts
+++ b/src/app.ts
@@ -45,10 +45,7 @@ app.use(`/api/${API_VERSION}`, router);
 
 // Global error handler for unhandled errors
 app.use((err: any, _req: Request, res: Response, _next: NextFunction) => {
-    logger.error(
-        { err: err instanceof Error ? { message: err.message, stack: err.stack } : err },
-        '[GlobalErrorHandler] Unhandled error',
-    );
+    logger.error({ err }, '[GlobalErrorHandler] Unhandled error');
     res.status(500).json({
         message: 'An unexpected error occurred.',
     });

--- a/src/app.ts
+++ b/src/app.ts
@@ -7,10 +7,8 @@ import swaggerDocument from './swagger/swagger.json';
 import { updateSwagger } from './swagger/helpers';
 import { API_VERSION, DOMAIN, EXTERNAL_PORT, MAX_UPLOAD_SIZE, PROTOCOL } from './config';
 import { buildBaseUrl } from './utils';
-import { getLogger } from './services/logging';
+import { apiLogger as logger } from './services/logging';
 import { correlationIdMiddleware } from './middleware/correlation-id';
-
-const logger = getLogger();
 
 export const app = express();
 

--- a/src/bucket-config.ts
+++ b/src/bucket-config.ts
@@ -1,6 +1,4 @@
-import { getLogger } from './services/logging';
-
-const logger = getLogger();
+import { configLogger as logger } from './services/logging';
 
 interface BucketConfiguration {
     /** The default bucket name, or undefined if not configured. Always a member of AVAILABLE_BUCKETS when defined. */

--- a/src/bucket-config.ts
+++ b/src/bucket-config.ts
@@ -1,3 +1,7 @@
+import { getLogger } from './services/logging';
+
+const logger = getLogger();
+
 interface BucketConfiguration {
     /** The default bucket name, or undefined if not configured. Always a member of AVAILABLE_BUCKETS when defined. */
     DEFAULT_BUCKET: string | undefined;
@@ -14,9 +18,9 @@ export function getBucketConfiguration(env: NodeJS.ProcessEnv): BucketConfigurat
     const shouldAutoAddDefaultBucket = DEFAULT_BUCKET && !configuredBuckets.includes(DEFAULT_BUCKET);
 
     if (shouldAutoAddDefaultBucket) {
-        console.warn(
-            `[config] DEFAULT_BUCKET="${DEFAULT_BUCKET}" is not in AVAILABLE_BUCKETS (${configuredBuckets.join(', ')}). ` +
-                'It will be auto-added, but consider including it in AVAILABLE_BUCKETS explicitly.',
+        logger.warn(
+            { defaultBucket: DEFAULT_BUCKET, configuredBuckets },
+            '[config] DEFAULT_BUCKET is not in AVAILABLE_BUCKETS. It will be auto-added, but consider including it in AVAILABLE_BUCKETS explicitly.',
         );
     }
 

--- a/src/middleware/authentication.ts
+++ b/src/middleware/authentication.ts
@@ -1,10 +1,9 @@
 import { NextFunction, Request, Response } from 'express';
 import { UnauthorizedError } from '../errors';
 import { ApiKeyAuthenticationService } from '../services/authentication';
-import { getLogger } from '../services/logging';
+import { authLogger as logger } from '../services/logging';
 
 const authService = new ApiKeyAuthenticationService();
-const logger = getLogger();
 
 /**
  * Middleware to authenticate requests using API key authentication.

--- a/src/middleware/authentication.ts
+++ b/src/middleware/authentication.ts
@@ -23,10 +23,7 @@ export const authenticateRequest = async (req: Request, res: Response, next: Nex
 
         next();
     } catch (err: any) {
-        logger.info(
-            { err: err instanceof Error ? err.message : err },
-            '[AuthenticationMiddleware] Authentication failed',
-        );
+        logger.info({ err }, '[AuthenticationMiddleware] Authentication failed');
 
         if (err instanceof UnauthorizedError) {
             return res.status(err.statusCode).json({ message: err.message });

--- a/src/middleware/authentication.ts
+++ b/src/middleware/authentication.ts
@@ -1,8 +1,10 @@
 import { NextFunction, Request, Response } from 'express';
 import { UnauthorizedError } from '../errors';
 import { ApiKeyAuthenticationService } from '../services/authentication';
+import { getLogger } from '../services/logging';
 
 const authService = new ApiKeyAuthenticationService();
+const logger = getLogger();
 
 /**
  * Middleware to authenticate requests using API key authentication.
@@ -22,7 +24,10 @@ export const authenticateRequest = async (req: Request, res: Response, next: Nex
 
         next();
     } catch (err: any) {
-        console.log('[AuthenticationMiddleware] Authentication failed.', err);
+        logger.info(
+            { err: err instanceof Error ? err.message : err },
+            '[AuthenticationMiddleware] Authentication failed',
+        );
 
         if (err instanceof UnauthorizedError) {
             return res.status(err.statusCode).json({ message: err.message });

--- a/src/middleware/correlation-id.test.ts
+++ b/src/middleware/correlation-id.test.ts
@@ -1,0 +1,115 @@
+import { getMockReq, getMockRes } from '@jest-mock/express';
+import { correlationIdMiddleware } from './correlation-id';
+import { getRequestContext } from '../services/logging';
+import type { LoggerService } from '../services/logging';
+
+function buildMockLogger(): jest.Mocked<LoggerService> {
+    const logger: any = {
+        debug: jest.fn(),
+        info: jest.fn(),
+        warn: jest.fn(),
+        error: jest.fn(),
+    };
+    logger.child = jest.fn(() => logger);
+    return logger;
+}
+
+describe('correlationIdMiddleware', () => {
+    const UUID_PATTERN = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+    let logger: jest.Mocked<LoggerService>;
+
+    beforeEach(() => {
+        logger = buildMockLogger();
+    });
+
+    it('uses the inbound x-correlation-id when it is valid', () => {
+        const inbound = 'request-12345_abc';
+        const req = getMockReq({ headers: { 'x-correlation-id': inbound } });
+        const { res, next } = getMockRes();
+
+        let observed: string | undefined;
+        const captureContext = () => {
+            observed = getRequestContext()?.correlationId;
+        };
+
+        correlationIdMiddleware(logger)(req, res, () => captureContext());
+
+        expect(observed).toBe(inbound);
+        expect(res.setHeader).toHaveBeenCalledWith('x-correlation-id', inbound);
+        expect(logger.warn).not.toHaveBeenCalled();
+    });
+
+    it('mints a fresh UUID when no header is present', () => {
+        const req = getMockReq();
+        const { res, next } = getMockRes();
+
+        let observed: string | undefined;
+        correlationIdMiddleware(logger)(req, res, () => {
+            observed = getRequestContext()?.correlationId;
+        });
+
+        expect(observed).toMatch(UUID_PATTERN);
+        expect(res.setHeader).toHaveBeenCalledWith('x-correlation-id', observed);
+        expect(logger.warn).not.toHaveBeenCalled();
+    });
+
+    it('mints a fresh UUID and warns when the header fails validation', () => {
+        const malformed = 'has whitespace and unicode  bell';
+        const req = getMockReq({ headers: { 'x-correlation-id': malformed } });
+        const { res, next } = getMockRes();
+
+        let observed: string | undefined;
+        correlationIdMiddleware(logger)(req, res, () => {
+            observed = getRequestContext()?.correlationId;
+        });
+
+        expect(observed).toMatch(UUID_PATTERN);
+        expect(observed).not.toBe(malformed);
+        expect(res.setHeader).toHaveBeenCalledWith('x-correlation-id', observed);
+        expect(logger.warn).toHaveBeenCalledWith(
+            expect.objectContaining({ inboundLength: malformed.length, replacedWith: observed }),
+            expect.stringContaining('Rejected invalid x-correlation-id header'),
+        );
+    });
+
+    it('rejects a header that exceeds the length cap', () => {
+        const tooLong = 'a'.repeat(129);
+        const req = getMockReq({ headers: { 'x-correlation-id': tooLong } });
+        const { res, next } = getMockRes();
+
+        let observed: string | undefined;
+        correlationIdMiddleware(logger)(req, res, () => {
+            observed = getRequestContext()?.correlationId;
+        });
+
+        expect(observed).toMatch(UUID_PATTERN);
+        expect(observed).not.toBe(tooLong);
+        expect(logger.warn).toHaveBeenCalled();
+    });
+
+    it('rejects an empty-string header', () => {
+        const req = getMockReq({ headers: { 'x-correlation-id': '' } });
+        const { res, next } = getMockRes();
+
+        let observed: string | undefined;
+        correlationIdMiddleware(logger)(req, res, () => {
+            observed = getRequestContext()?.correlationId;
+        });
+
+        expect(observed).toMatch(UUID_PATTERN);
+        expect(logger.warn).toHaveBeenCalled();
+    });
+
+    it('uses the first value when the header is multi-valued', () => {
+        const req = getMockReq({ headers: { 'x-correlation-id': ['first-value', 'second-value'] as any } });
+        const { res, next } = getMockRes();
+
+        let observed: string | undefined;
+        correlationIdMiddleware(logger)(req, res, () => {
+            observed = getRequestContext()?.correlationId;
+        });
+
+        expect(observed).toBe('first-value');
+        expect(logger.warn).not.toHaveBeenCalled();
+    });
+});

--- a/src/middleware/correlation-id.test.ts
+++ b/src/middleware/correlation-id.test.ts
@@ -9,6 +9,7 @@ function buildMockLogger(): jest.Mocked<LoggerService> {
         info: jest.fn(),
         warn: jest.fn(),
         error: jest.fn(),
+        fatal: jest.fn(),
     };
     logger.child = jest.fn(() => logger);
     return logger;

--- a/src/middleware/correlation-id.ts
+++ b/src/middleware/correlation-id.ts
@@ -1,0 +1,53 @@
+import crypto from 'crypto';
+import type { RequestHandler } from 'express';
+import { runWithRequestContext } from '../services/logging';
+import type { LoggerService } from '../services/logging';
+
+const CORRELATION_ID_HEADER = 'x-correlation-id';
+const MAX_CORRELATION_ID_LENGTH = 128;
+const CORRELATION_ID_PATTERN = /^[A-Za-z0-9_-]+$/;
+
+function isValidCorrelationId(value: string): boolean {
+    return value.length > 0 && value.length <= MAX_CORRELATION_ID_LENGTH && CORRELATION_ID_PATTERN.test(value);
+}
+
+/**
+ * Express middleware that establishes a request-scoped correlation ID.
+ *
+ * The inbound `x-correlation-id` header is validated (length cap, alphanumeric
+ * plus `-` and `_`) before being trusted. Invalid or missing values are
+ * replaced by a fresh `crypto.randomUUID()`; rejection of a malformed value is
+ * recorded as a `warn` log line (the offending payload is not echoed back to
+ * keep the log line safe from injection content).
+ *
+ * The resolved correlation ID is:
+ *  1. Available to every handler / log line via `getRequestContext()` (Pino's
+ *     mixin picks it up automatically).
+ *  2. Echoed on the response as `x-correlation-id` so callers can trace the
+ *     request without parsing the body.
+ */
+export function correlationIdMiddleware(logger: LoggerService): RequestHandler {
+    return (req, res, next) => {
+        const headerValue = req.headers[CORRELATION_ID_HEADER];
+        const inbound = Array.isArray(headerValue) ? headerValue[0] : headerValue;
+
+        let correlationId: string;
+        if (inbound === undefined) {
+            correlationId = crypto.randomUUID();
+        } else if (isValidCorrelationId(inbound)) {
+            correlationId = inbound;
+        } else {
+            correlationId = crypto.randomUUID();
+            logger.warn(
+                {
+                    inboundLength: inbound.length,
+                    replacedWith: correlationId,
+                },
+                'Rejected invalid x-correlation-id header; minted a fresh id',
+            );
+        }
+
+        res.setHeader(CORRELATION_ID_HEADER, correlationId);
+        runWithRequestContext(correlationId, () => next());
+    };
+}

--- a/src/routes/delete/controller.ts
+++ b/src/routes/delete/controller.ts
@@ -17,10 +17,7 @@ export const deleteResource: RequestHandler = async (req, res) => {
 
         res.status(204).send();
     } catch (err: any) {
-        logger.error(
-            { err: err instanceof Error ? err.message : err },
-            '[DeleteController.deleteResource] An error occurred while deleting the resource',
-        );
+        logger.error({ err }, '[DeleteController.deleteResource] An error occurred while deleting the resource');
 
         if (err instanceof ApiError) {
             return res.status(err.statusCode).json({ message: err.message });

--- a/src/routes/delete/controller.ts
+++ b/src/routes/delete/controller.ts
@@ -2,9 +2,9 @@ import { RequestHandler } from 'express';
 import { initialiseStorageService, IStorageService } from '../../services';
 import { DeleteService } from './service';
 import { ApiError } from '../../errors';
-import { getLogger } from '../../services/logging';
+import { apiLogger } from '../../services/logging';
 
-const logger = getLogger();
+const logger = apiLogger.child({ route: 'DELETE /:bucket/:id' });
 
 export const deleteResource: RequestHandler = async (req, res) => {
     try {

--- a/src/routes/delete/controller.ts
+++ b/src/routes/delete/controller.ts
@@ -2,6 +2,9 @@ import { RequestHandler } from 'express';
 import { initialiseStorageService, IStorageService } from '../../services';
 import { DeleteService } from './service';
 import { ApiError } from '../../errors';
+import { getLogger } from '../../services/logging';
+
+const logger = getLogger();
 
 export const deleteResource: RequestHandler = async (req, res) => {
     try {
@@ -14,7 +17,10 @@ export const deleteResource: RequestHandler = async (req, res) => {
 
         res.status(204).send();
     } catch (err: any) {
-        console.error('[DeleteController.deleteResource] An error occurred while deleting the resource.', err);
+        logger.error(
+            { err: err instanceof Error ? err.message : err },
+            '[DeleteController.deleteResource] An error occurred while deleting the resource',
+        );
 
         if (err instanceof ApiError) {
             return res.status(err.statusCode).json({ message: err.message });

--- a/src/routes/delete/service.ts
+++ b/src/routes/delete/service.ts
@@ -25,10 +25,7 @@ export class DeleteService {
 
             await Promise.all(matchingKeys.map((key) => storageService.deleteFile(bucket, key)));
         } catch (err: any) {
-            logger.error(
-                { err: err instanceof Error ? err.message : err },
-                '[DeleteService.deleteDocument] An error occurred while deleting the resource',
-            );
+            logger.error({ err }, '[DeleteService.deleteDocument] An error occurred while deleting the resource');
 
             if (err instanceof ApiError) {
                 throw err;

--- a/src/routes/delete/service.ts
+++ b/src/routes/delete/service.ts
@@ -2,9 +2,7 @@ import { IStorageService } from '../../services';
 import { ApiError, ApplicationError, BadRequestError, NotFoundError } from '../../errors';
 import { AVAILABLE_BUCKETS } from '../../config';
 import { isValidUUID } from '../../utils';
-import { getLogger } from '../../services/logging';
-
-const logger = getLogger();
+import { apiLogger as logger } from '../../services/logging';
 
 export class DeleteService {
     public async deleteDocument(storageService: IStorageService, bucket: string, id: string): Promise<void> {

--- a/src/routes/delete/service.ts
+++ b/src/routes/delete/service.ts
@@ -2,6 +2,9 @@ import { IStorageService } from '../../services';
 import { ApiError, ApplicationError, BadRequestError, NotFoundError } from '../../errors';
 import { AVAILABLE_BUCKETS } from '../../config';
 import { isValidUUID } from '../../utils';
+import { getLogger } from '../../services/logging';
+
+const logger = getLogger();
 
 export class DeleteService {
     public async deleteDocument(storageService: IStorageService, bucket: string, id: string): Promise<void> {
@@ -24,7 +27,10 @@ export class DeleteService {
 
             await Promise.all(matchingKeys.map((key) => storageService.deleteFile(bucket, key)));
         } catch (err: any) {
-            console.error('[DeleteService.deleteDocument] An error occurred while deleting the resource.', err);
+            logger.error(
+                { err: err instanceof Error ? err.message : err },
+                '[DeleteService.deleteDocument] An error occurred while deleting the resource',
+            );
 
             if (err instanceof ApiError) {
                 throw err;

--- a/src/routes/private/controller.test.ts
+++ b/src/routes/private/controller.test.ts
@@ -12,6 +12,12 @@ mockLogger.child = jest.fn(() => mockLogger);
 
 jest.mock('../../services/logging', () => ({
     getLogger: () => mockLogger,
+    apiLogger: mockLogger,
+    authLogger: mockLogger,
+    cryptoLogger: mockLogger,
+    storageLogger: mockLogger,
+    configLogger: mockLogger,
+    serverLogger: mockLogger,
 }));
 
 import { BadRequestError } from '../../errors';

--- a/src/routes/private/controller.test.ts
+++ b/src/routes/private/controller.test.ts
@@ -1,6 +1,19 @@
 import os from 'os';
 import path from 'path';
 import { getMockReq, getMockRes } from '@jest-mock/express';
+
+const mockLogger: any = {
+    debug: jest.fn(),
+    info: jest.fn(),
+    warn: jest.fn(),
+    error: jest.fn(),
+};
+mockLogger.child = jest.fn(() => mockLogger);
+
+jest.mock('../../services/logging', () => ({
+    getLogger: () => mockLogger,
+}));
+
 import { BadRequestError } from '../../errors';
 import { PrivateService } from './service';
 
@@ -243,7 +256,6 @@ describe('Private Controller', () => {
             (fs.promises.unlink as jest.Mock).mockRejectedValueOnce(
                 Object.assign(new Error('EACCES: permission denied'), { code: 'EACCES' }),
             );
-            const consoleSpy = jest.spyOn(console, 'error').mockImplementation();
 
             jest.spyOn(PrivateService.prototype, 'encryptAndStoreFile').mockResolvedValue({
                 uri: 'mock-uri',
@@ -260,13 +272,10 @@ describe('Private Controller', () => {
             await storePrivate(mockReq, mockRes, mockNext);
 
             expect(fs.promises.unlink).toHaveBeenCalledWith(path.resolve(tempPath));
-            expect(consoleSpy).toHaveBeenCalledWith(
+            expect(mockLogger.error).toHaveBeenCalledWith(
+                expect.objectContaining({ tempPath: expect.any(String), err: expect.any(String) }),
                 expect.stringContaining('Failed to clean up temp file'),
-                expect.any(String),
-                expect.any(Error),
             );
-
-            consoleSpy.mockRestore();
         });
 
         it('should return 400 when file path is outside the upload directory', async () => {

--- a/src/routes/private/controller.test.ts
+++ b/src/routes/private/controller.test.ts
@@ -7,6 +7,7 @@ const mockLogger: any = {
     info: jest.fn(),
     warn: jest.fn(),
     error: jest.fn(),
+    fatal: jest.fn(),
 };
 mockLogger.child = jest.fn(() => mockLogger);
 
@@ -279,7 +280,7 @@ describe('Private Controller', () => {
 
             expect(fs.promises.unlink).toHaveBeenCalledWith(path.resolve(tempPath));
             expect(mockLogger.error).toHaveBeenCalledWith(
-                expect.objectContaining({ tempPath: expect.any(String), err: expect.any(String) }),
+                expect.objectContaining({ tempPath: expect.any(String), err: expect.any(Error) }),
                 expect.stringContaining('Failed to clean up temp file'),
             );
         });

--- a/src/routes/private/controller.ts
+++ b/src/routes/private/controller.ts
@@ -58,10 +58,7 @@ export const storePrivate: RequestHandler = async (req, res) => {
 
         res.status(201).json(response);
     } catch (err: any) {
-        logger.error(
-            { err: err instanceof Error ? err.message : err },
-            '[PrivateController.storePrivate] An error occurred while storing private data',
-        );
+        logger.error({ err }, '[PrivateController.storePrivate] An error occurred while storing private data');
 
         if (err instanceof ApiError) {
             return res.status(err.statusCode).json({ message: err.message });
@@ -77,7 +74,7 @@ export const storePrivate: RequestHandler = async (req, res) => {
             } catch (cleanupErr: any) {
                 if (cleanupErr.code !== 'ENOENT') {
                     logger.error(
-                        { tempPath, err: cleanupErr instanceof Error ? cleanupErr.message : cleanupErr },
+                        { tempPath, err: cleanupErr },
                         '[PrivateController.storePrivate] Failed to clean up temp file',
                     );
                 }

--- a/src/routes/private/controller.ts
+++ b/src/routes/private/controller.ts
@@ -5,7 +5,9 @@ import { RequestHandler } from 'express';
 import { CryptographyService, IStorageService, initialiseStorageService } from '../../services';
 import { ApiError, BadRequestError } from '../../errors';
 import { PrivateService } from './service';
+import { getLogger } from '../../services/logging';
 
+const logger = getLogger();
 const UPLOAD_DIR = path.resolve(os.tmpdir());
 
 /**
@@ -56,7 +58,10 @@ export const storePrivate: RequestHandler = async (req, res) => {
 
         res.status(201).json(response);
     } catch (err: any) {
-        console.error('[PrivateController.storePrivate] An error occurred while storing private data.', err);
+        logger.error(
+            { err: err instanceof Error ? err.message : err },
+            '[PrivateController.storePrivate] An error occurred while storing private data',
+        );
 
         if (err instanceof ApiError) {
             return res.status(err.statusCode).json({ message: err.message });
@@ -71,10 +76,9 @@ export const storePrivate: RequestHandler = async (req, res) => {
                 await fs.promises.unlink(tempPath);
             } catch (cleanupErr: any) {
                 if (cleanupErr.code !== 'ENOENT') {
-                    console.error(
-                        '[PrivateController.storePrivate] Failed to clean up temp file %s:',
-                        tempPath,
-                        cleanupErr,
+                    logger.error(
+                        { tempPath, err: cleanupErr instanceof Error ? cleanupErr.message : cleanupErr },
+                        '[PrivateController.storePrivate] Failed to clean up temp file',
                     );
                 }
             }

--- a/src/routes/private/controller.ts
+++ b/src/routes/private/controller.ts
@@ -5,9 +5,9 @@ import { RequestHandler } from 'express';
 import { CryptographyService, IStorageService, initialiseStorageService } from '../../services';
 import { ApiError, BadRequestError } from '../../errors';
 import { PrivateService } from './service';
-import { getLogger } from '../../services/logging';
+import { apiLogger } from '../../services/logging';
 
-const logger = getLogger();
+const logger = apiLogger.child({ route: 'POST /private' });
 const UPLOAD_DIR = path.resolve(os.tmpdir());
 
 /**

--- a/src/routes/private/service.ts
+++ b/src/routes/private/service.ts
@@ -99,7 +99,7 @@ export class PrivateService {
             };
         } catch (err: any) {
             logger.error(
-                { err: err instanceof Error ? err.message : err },
+                { err },
                 '[PrivateService.encryptAndStoreDocument] An error occurred while encrypting and storing the document',
             );
 
@@ -212,7 +212,7 @@ export class PrivateService {
             };
         } catch (err: any) {
             logger.error(
-                { err: err instanceof Error ? err.message : err },
+                { err },
                 '[PrivateService.encryptAndStoreFile] An error occurred while encrypting and storing the file',
             );
 

--- a/src/routes/private/service.ts
+++ b/src/routes/private/service.ts
@@ -5,9 +5,7 @@ import { AVAILABLE_BUCKETS, ALLOWED_UPLOAD_TYPES, DEFAULT_BUCKET } from '../../c
 import { IStoreParams, IStoreFileParams } from '../../types';
 import { isValidUUID } from '../../utils';
 import { ApiError, ApplicationError, BadRequestError, ConflictError } from '../../errors';
-import { getLogger } from '../../services/logging';
-
-const logger = getLogger();
+import { apiLogger as logger } from '../../services/logging';
 
 export class PrivateService {
     /**

--- a/src/routes/private/service.ts
+++ b/src/routes/private/service.ts
@@ -5,6 +5,9 @@ import { AVAILABLE_BUCKETS, ALLOWED_UPLOAD_TYPES, DEFAULT_BUCKET } from '../../c
 import { IStoreParams, IStoreFileParams } from '../../types';
 import { isValidUUID } from '../../utils';
 import { ApiError, ApplicationError, BadRequestError, ConflictError } from '../../errors';
+import { getLogger } from '../../services/logging';
+
+const logger = getLogger();
 
 export class PrivateService {
     /**
@@ -36,8 +39,9 @@ export class PrivateService {
             const resolvedBucket = bucket || DEFAULT_BUCKET;
 
             if (!bucket && resolvedBucket) {
-                console.info(
-                    `[PrivateService.encryptAndStoreDocument] No bucket specified; using DEFAULT_BUCKET="${resolvedBucket}"`,
+                logger.info(
+                    { defaultBucket: resolvedBucket },
+                    '[PrivateService.encryptAndStoreDocument] No bucket specified; falling back to DEFAULT_BUCKET',
                 );
             }
 
@@ -96,9 +100,9 @@ export class PrivateService {
                 decryptionKey: key,
             };
         } catch (err: any) {
-            console.error(
-                '[PrivateService.encryptAndStoreDocument] An error occurred while encrypting and storing the document.',
-                err,
+            logger.error(
+                { err: err instanceof Error ? err.message : err },
+                '[PrivateService.encryptAndStoreDocument] An error occurred while encrypting and storing the document',
             );
 
             if (err instanceof ApiError) {
@@ -142,8 +146,9 @@ export class PrivateService {
             const resolvedBucket = bucket || DEFAULT_BUCKET;
 
             if (!bucket && resolvedBucket) {
-                console.info(
-                    `[PrivateService.encryptAndStoreFile] No bucket specified; using DEFAULT_BUCKET="${resolvedBucket}"`,
+                logger.info(
+                    { defaultBucket: resolvedBucket },
+                    '[PrivateService.encryptAndStoreFile] No bucket specified; falling back to DEFAULT_BUCKET',
                 );
             }
 
@@ -208,9 +213,9 @@ export class PrivateService {
                 decryptionKey: key,
             };
         } catch (err: any) {
-            console.error(
-                '[PrivateService.encryptAndStoreFile] An error occurred while encrypting and storing the file.',
-                err,
+            logger.error(
+                { err: err instanceof Error ? err.message : err },
+                '[PrivateService.encryptAndStoreFile] An error occurred while encrypting and storing the file',
             );
 
             if (err instanceof ApiError) {

--- a/src/routes/public/controller.test.ts
+++ b/src/routes/public/controller.test.ts
@@ -2,6 +2,19 @@ import fs from 'fs';
 import os from 'os';
 import path from 'path';
 import { getMockReq, getMockRes } from '@jest-mock/express';
+
+const mockLogger: any = {
+    debug: jest.fn(),
+    info: jest.fn(),
+    warn: jest.fn(),
+    error: jest.fn(),
+};
+mockLogger.child = jest.fn(() => mockLogger);
+
+jest.mock('../../services/logging', () => ({
+    getLogger: () => mockLogger,
+}));
+
 import { storePublic } from './controller';
 import { PublicService } from './service';
 import { BadRequestError } from '../../errors';
@@ -230,7 +243,6 @@ describe('PublicController', () => {
             (fs.promises.unlink as jest.Mock).mockRejectedValueOnce(
                 Object.assign(new Error('EACCES: permission denied'), { code: 'EACCES' }),
             );
-            const consoleSpy = jest.spyOn(console, 'error').mockImplementation();
 
             jest.spyOn(PublicService.prototype, 'storeFile').mockResolvedValue({
                 uri: 'mock-uri',
@@ -246,13 +258,10 @@ describe('PublicController', () => {
             await storePublic(mockReq, mockRes, mockNext);
 
             expect(fs.promises.unlink).toHaveBeenCalledWith(path.resolve(tempPath));
-            expect(consoleSpy).toHaveBeenCalledWith(
+            expect(mockLogger.error).toHaveBeenCalledWith(
+                expect.objectContaining({ tempPath: expect.any(String), err: expect.any(String) }),
                 expect.stringContaining('Failed to clean up temp file'),
-                expect.any(String),
-                expect.any(Error),
             );
-
-            consoleSpy.mockRestore();
         });
 
         it('should return 400 when file path is outside the upload directory', async () => {

--- a/src/routes/public/controller.test.ts
+++ b/src/routes/public/controller.test.ts
@@ -8,6 +8,7 @@ const mockLogger: any = {
     info: jest.fn(),
     warn: jest.fn(),
     error: jest.fn(),
+    fatal: jest.fn(),
 };
 mockLogger.child = jest.fn(() => mockLogger);
 
@@ -265,7 +266,7 @@ describe('PublicController', () => {
 
             expect(fs.promises.unlink).toHaveBeenCalledWith(path.resolve(tempPath));
             expect(mockLogger.error).toHaveBeenCalledWith(
-                expect.objectContaining({ tempPath: expect.any(String), err: expect.any(String) }),
+                expect.objectContaining({ tempPath: expect.any(String), err: expect.any(Error) }),
                 expect.stringContaining('Failed to clean up temp file'),
             );
         });

--- a/src/routes/public/controller.test.ts
+++ b/src/routes/public/controller.test.ts
@@ -13,6 +13,12 @@ mockLogger.child = jest.fn(() => mockLogger);
 
 jest.mock('../../services/logging', () => ({
     getLogger: () => mockLogger,
+    apiLogger: mockLogger,
+    authLogger: mockLogger,
+    cryptoLogger: mockLogger,
+    storageLogger: mockLogger,
+    configLogger: mockLogger,
+    serverLogger: mockLogger,
 }));
 
 import { storePublic } from './controller';

--- a/src/routes/public/controller.ts
+++ b/src/routes/public/controller.ts
@@ -58,10 +58,7 @@ export const storePublic: RequestHandler = async (req, res) => {
 
         res.status(201).json(response);
     } catch (err: any) {
-        logger.error(
-            { err: err instanceof Error ? err.message : err },
-            '[PublicController.storePublic] An error occurred while storing the resource',
-        );
+        logger.error({ err }, '[PublicController.storePublic] An error occurred while storing the resource');
 
         if (err instanceof ApiError) {
             return res.status(err.statusCode).json({ message: err.message });
@@ -77,7 +74,7 @@ export const storePublic: RequestHandler = async (req, res) => {
             } catch (cleanupErr: any) {
                 if (cleanupErr.code !== 'ENOENT') {
                     logger.error(
-                        { tempPath, err: cleanupErr instanceof Error ? cleanupErr.message : cleanupErr },
+                        { tempPath, err: cleanupErr },
                         '[PublicController.storePublic] Failed to clean up temp file',
                     );
                 }

--- a/src/routes/public/controller.ts
+++ b/src/routes/public/controller.ts
@@ -5,9 +5,9 @@ import { RequestHandler } from 'express';
 import { initialiseStorageService, CryptographyService, IStorageService } from '../../services';
 import { PublicService } from './service';
 import { ApiError, BadRequestError } from '../../errors';
-import { getLogger } from '../../services/logging';
+import { apiLogger } from '../../services/logging';
 
-const logger = getLogger();
+const logger = apiLogger.child({ route: 'POST /public' });
 const UPLOAD_DIR = path.resolve(os.tmpdir());
 
 /**

--- a/src/routes/public/controller.ts
+++ b/src/routes/public/controller.ts
@@ -5,7 +5,9 @@ import { RequestHandler } from 'express';
 import { initialiseStorageService, CryptographyService, IStorageService } from '../../services';
 import { PublicService } from './service';
 import { ApiError, BadRequestError } from '../../errors';
+import { getLogger } from '../../services/logging';
 
+const logger = getLogger();
 const UPLOAD_DIR = path.resolve(os.tmpdir());
 
 /**
@@ -56,7 +58,10 @@ export const storePublic: RequestHandler = async (req, res) => {
 
         res.status(201).json(response);
     } catch (err: any) {
-        console.error('[PublicController.storePublic] An error occurred while storing the resource.', err);
+        logger.error(
+            { err: err instanceof Error ? err.message : err },
+            '[PublicController.storePublic] An error occurred while storing the resource',
+        );
 
         if (err instanceof ApiError) {
             return res.status(err.statusCode).json({ message: err.message });
@@ -71,10 +76,9 @@ export const storePublic: RequestHandler = async (req, res) => {
                 await fs.promises.unlink(tempPath);
             } catch (cleanupErr: any) {
                 if (cleanupErr.code !== 'ENOENT') {
-                    console.error(
-                        '[PublicController.storePublic] Failed to clean up temp file %s:',
-                        tempPath,
-                        cleanupErr,
+                    logger.error(
+                        { tempPath, err: cleanupErr instanceof Error ? cleanupErr.message : cleanupErr },
+                        '[PublicController.storePublic] Failed to clean up temp file',
                     );
                 }
             }

--- a/src/routes/public/service.ts
+++ b/src/routes/public/service.ts
@@ -85,10 +85,7 @@ export class PublicService {
                 digestMultibase,
             };
         } catch (err: any) {
-            logger.error(
-                { err: err instanceof Error ? err.message : err },
-                '[PublicService.storeDocument] An error occurred while storing the document',
-            );
+            logger.error({ err }, '[PublicService.storeDocument] An error occurred while storing the document');
 
             if (err instanceof ApiError) {
                 throw err;
@@ -180,10 +177,7 @@ export class PublicService {
                 digestMultibase,
             };
         } catch (err: any) {
-            logger.error(
-                { err: err instanceof Error ? err.message : err },
-                '[PublicService.storeFile] An error occurred while storing the file',
-            );
+            logger.error({ err }, '[PublicService.storeFile] An error occurred while storing the file');
 
             if (err instanceof ApiError) {
                 throw err;

--- a/src/routes/public/service.ts
+++ b/src/routes/public/service.ts
@@ -6,9 +6,7 @@ import { ApiError, ApplicationError, BadRequestError, ConflictError } from '../.
 import { AVAILABLE_BUCKETS, ALLOWED_UPLOAD_TYPES, DEFAULT_BUCKET } from '../../config';
 import { isValidUUID } from '../../utils';
 import { IStoreParams, IStoreFileParams } from '../../types';
-import { getLogger } from '../../services/logging';
-
-const logger = getLogger();
+import { apiLogger as logger } from '../../services/logging';
 
 export class PublicService {
     /**

--- a/src/routes/public/service.ts
+++ b/src/routes/public/service.ts
@@ -6,6 +6,9 @@ import { ApiError, ApplicationError, BadRequestError, ConflictError } from '../.
 import { AVAILABLE_BUCKETS, ALLOWED_UPLOAD_TYPES, DEFAULT_BUCKET } from '../../config';
 import { isValidUUID } from '../../utils';
 import { IStoreParams, IStoreFileParams } from '../../types';
+import { getLogger } from '../../services/logging';
+
+const logger = getLogger();
 
 export class PublicService {
     /**
@@ -32,8 +35,9 @@ export class PublicService {
             const resolvedBucket = bucket || DEFAULT_BUCKET;
 
             if (!bucket && resolvedBucket) {
-                console.info(
-                    `[PublicService.storeDocument] No bucket specified; using DEFAULT_BUCKET="${resolvedBucket}"`,
+                logger.info(
+                    { defaultBucket: resolvedBucket },
+                    '[PublicService.storeDocument] No bucket specified; falling back to DEFAULT_BUCKET',
                 );
             }
 
@@ -83,7 +87,10 @@ export class PublicService {
                 digestMultibase,
             };
         } catch (err: any) {
-            console.error('[PublicService.storeDocument] An error occurred while storing the document.', err);
+            logger.error(
+                { err: err instanceof Error ? err.message : err },
+                '[PublicService.storeDocument] An error occurred while storing the document',
+            );
 
             if (err instanceof ApiError) {
                 throw err;
@@ -118,7 +125,10 @@ export class PublicService {
             const resolvedBucket = bucket || DEFAULT_BUCKET;
 
             if (!bucket && resolvedBucket) {
-                console.info(`[PublicService.storeFile] No bucket specified; using DEFAULT_BUCKET="${resolvedBucket}"`);
+                logger.info(
+                    { defaultBucket: resolvedBucket },
+                    '[PublicService.storeFile] No bucket specified; falling back to DEFAULT_BUCKET',
+                );
             }
 
             if (!resolvedBucket) {
@@ -172,7 +182,10 @@ export class PublicService {
                 digestMultibase,
             };
         } catch (err: any) {
-            console.error('[PublicService.storeFile] An error occurred while storing the file.', err);
+            logger.error(
+                { err: err instanceof Error ? err.message : err },
+                '[PublicService.storeFile] An error occurred while storing the file',
+            );
 
             if (err instanceof ApiError) {
                 throw err;

--- a/src/server.ts
+++ b/src/server.ts
@@ -5,14 +5,14 @@ import { serverLogger as logger } from './services/logging';
 
 // Validate required environment variables at runtime
 if (!getApiKey()) {
-    logger.error(
+    logger.fatal(
         'API_KEY environment variable is required but not set. Set API_KEY in your .env file or environment variables.',
     );
     process.exit(1);
 }
 
 if (isNaN(Number(EXTERNAL_PORT))) {
-    logger.error(
+    logger.fatal(
         { externalPort: EXTERNAL_PORT },
         'Invalid port configuration. EXTERNAL_PORT (or PORT as fallback) must be a valid number.',
     );
@@ -20,7 +20,7 @@ if (isNaN(Number(EXTERNAL_PORT))) {
 }
 
 if (isNaN(MAX_UPLOAD_SIZE) || MAX_UPLOAD_SIZE <= 0) {
-    logger.error(
+    logger.fatal(
         { maxUploadSize: process.env.MAX_UPLOAD_SIZE },
         'MAX_UPLOAD_SIZE must be a positive number (in bytes).',
     );

--- a/src/server.ts
+++ b/src/server.ts
@@ -1,30 +1,35 @@
 import { app } from './app';
 import { API_VERSION, DOMAIN, EXTERNAL_PORT, MAX_UPLOAD_SIZE, PORT, PROTOCOL, getApiKey } from './config';
 import { buildBaseUrl } from './utils';
+import { getLogger } from './services/logging';
+
+const logger = getLogger();
 
 // Validate required environment variables at runtime
 if (!getApiKey()) {
-    console.error('❌ ERROR: API_KEY environment variable is required but not set.');
-    console.error('Please set API_KEY in your .env file or environment variables.');
+    logger.error(
+        'API_KEY environment variable is required but not set. Set API_KEY in your .env file or environment variables.',
+    );
     process.exit(1);
 }
 
 if (isNaN(Number(EXTERNAL_PORT))) {
-    console.error(
-        `❌ ERROR: Invalid port configuration. EXTERNAL_PORT (or PORT as fallback) must be a valid number, but resolved to '${EXTERNAL_PORT}'.`,
+    logger.error(
+        { externalPort: EXTERNAL_PORT },
+        'Invalid port configuration. EXTERNAL_PORT (or PORT as fallback) must be a valid number.',
     );
     process.exit(1);
 }
 
 if (isNaN(MAX_UPLOAD_SIZE) || MAX_UPLOAD_SIZE <= 0) {
-    console.error(
-        `MAX_UPLOAD_SIZE must be a positive number (in bytes). Current value: '${process.env.MAX_UPLOAD_SIZE}'.`,
+    logger.error(
+        { maxUploadSize: process.env.MAX_UPLOAD_SIZE },
+        'MAX_UPLOAD_SIZE must be a positive number (in bytes).',
     );
     process.exit(1);
 }
 
 app.listen(PORT, () => {
     const base = buildBaseUrl(PROTOCOL, DOMAIN, EXTERNAL_PORT);
-    console.log(`Server is running: ${base}/api/${API_VERSION} 🚀`);
-    console.log(`API documentation: ${base}/api-docs 📚`);
+    logger.info({ url: `${base}/api/${API_VERSION}`, docsUrl: `${base}/api-docs` }, 'Server started');
 });

--- a/src/server.ts
+++ b/src/server.ts
@@ -1,9 +1,7 @@
 import { app } from './app';
 import { API_VERSION, DOMAIN, EXTERNAL_PORT, MAX_UPLOAD_SIZE, PORT, PROTOCOL, getApiKey } from './config';
 import { buildBaseUrl } from './utils';
-import { getLogger } from './services/logging';
-
-const logger = getLogger();
+import { serverLogger as logger } from './services/logging';
 
 // Validate required environment variables at runtime
 if (!getApiKey()) {

--- a/src/services/authentication/apiKey.ts
+++ b/src/services/authentication/apiKey.ts
@@ -44,10 +44,7 @@ export class ApiKeyAuthenticationService implements IAuthenticationService {
                 return invalidKeyResponse;
             }
         } catch (err: unknown) {
-            logger.error(
-                { err: err instanceof Error ? err.message : err },
-                '[ApiKeyAuthenticationService] Error comparing API keys',
-            );
+            logger.error({ err }, '[ApiKeyAuthenticationService] Error comparing API keys');
 
             return invalidKeyResponse;
         }

--- a/src/services/authentication/apiKey.ts
+++ b/src/services/authentication/apiKey.ts
@@ -2,6 +2,9 @@ import crypto from 'crypto';
 import { Request } from 'express';
 import { AuthResult, IAuthenticationService } from '.';
 import { AUTH_HEADER_NAME, getApiKey } from '../../config';
+import { getLogger } from '../logging';
+
+const logger = getLogger();
 
 export class ApiKeyAuthenticationService implements IAuthenticationService {
     /**
@@ -43,7 +46,10 @@ export class ApiKeyAuthenticationService implements IAuthenticationService {
                 return invalidKeyResponse;
             }
         } catch (err: unknown) {
-            console.error('[ApiKeyAuthenticationService] Error comparing API keys:', err);
+            logger.error(
+                { err: err instanceof Error ? err.message : err },
+                '[ApiKeyAuthenticationService] Error comparing API keys',
+            );
 
             return invalidKeyResponse;
         }

--- a/src/services/authentication/apiKey.ts
+++ b/src/services/authentication/apiKey.ts
@@ -2,9 +2,7 @@ import crypto from 'crypto';
 import { Request } from 'express';
 import { AuthResult, IAuthenticationService } from '.';
 import { AUTH_HEADER_NAME, getApiKey } from '../../config';
-import { getLogger } from '../logging';
-
-const logger = getLogger();
+import { authLogger as logger } from '../logging';
 
 export class ApiKeyAuthenticationService implements IAuthenticationService {
     /**

--- a/src/services/cryptography/crypto.ts
+++ b/src/services/cryptography/crypto.ts
@@ -35,7 +35,7 @@ async function loadMultibaseDigest(): Promise<MultibaseDigestModule> {
         const pending = importEsm<MultibaseDigestModule>('@uncefact/untp-utils/multibase-digest');
         pending.catch((err) => {
             logger.error(
-                { err: err instanceof Error ? err.message : err },
+                { err },
                 '[CryptographyService] Failed to dynamically import "@uncefact/untp-utils/multibase-digest"; the module cache will be cleared so the next call retries.',
             );
             if (digestMultibaseModulePromise === pending) {
@@ -70,7 +70,7 @@ export class CryptographyService implements ICryptographyService {
             return digest.toString();
         } catch (err) {
             logger.error(
-                { algorithm, base, bytes: bytes.byteLength, err: err instanceof Error ? err.message : err },
+                { algorithm, base, bytes: bytes.byteLength, err },
                 '[CryptographyService.computeDigestMultibase] MultibaseDigest.fromData failed',
             );
             throw err;

--- a/src/services/cryptography/crypto.ts
+++ b/src/services/cryptography/crypto.ts
@@ -12,6 +12,10 @@ import {
     IEncryptionResult,
 } from './index';
 
+import { getLogger } from '../logging';
+
+const logger = getLogger();
+
 type MultibaseDigestModule = typeof import('@uncefact/untp-utils/multibase-digest');
 
 // @uncefact/untp-utils ships ESM only. ts-jest (and `tsc` with `module: "commonjs"`)
@@ -32,9 +36,9 @@ async function loadMultibaseDigest(): Promise<MultibaseDigestModule> {
     if (!digestMultibaseModulePromise) {
         const pending = importEsm<MultibaseDigestModule>('@uncefact/untp-utils/multibase-digest');
         pending.catch((err) => {
-            console.error(
+            logger.error(
+                { err: err instanceof Error ? err.message : err },
                 '[CryptographyService] Failed to dynamically import "@uncefact/untp-utils/multibase-digest"; the module cache will be cleared so the next call retries.',
-                err,
             );
             if (digestMultibaseModulePromise === pending) {
                 digestMultibaseModulePromise = undefined;
@@ -67,10 +71,9 @@ export class CryptographyService implements ICryptographyService {
             const digest = await MultibaseDigest.fromData(bytes, { algorithm, base });
             return digest.toString();
         } catch (err) {
-            console.error(
+            logger.error(
+                { algorithm, base, bytes: bytes.byteLength, err: err instanceof Error ? err.message : err },
                 '[CryptographyService.computeDigestMultibase] MultibaseDigest.fromData failed',
-                { algorithm, base, bytes: bytes.byteLength },
-                err,
             );
             throw err;
         }

--- a/src/services/cryptography/crypto.ts
+++ b/src/services/cryptography/crypto.ts
@@ -12,9 +12,7 @@ import {
     IEncryptionResult,
 } from './index';
 
-import { getLogger } from '../logging';
-
-const logger = getLogger();
+import { cryptoLogger as logger } from '../logging';
 
 type MultibaseDigestModule = typeof import('@uncefact/untp-utils/multibase-digest');
 

--- a/src/services/logging/index.ts
+++ b/src/services/logging/index.ts
@@ -20,9 +20,10 @@ let rootLogger: LoggerService | undefined;
 
 /**
  * Returns the process-wide root logger, instantiating it on first access from
- * `LOG_LEVEL` / `LOG_PRETTY` environment variables. Modules that need a logger
- * should call this and (optionally) attach a `child` binding with their name
- * so log lines self-identify in aggregation.
+ * `LOG_LEVEL` / `LOG_PRETTY` environment variables. Modules should not use this
+ * directly; pick the matching pre-bound logger from this barrel (e.g.
+ * {@link apiLogger}, {@link authLogger}) or attach a `.child({ module: '...' })`
+ * binding so log lines self-identify when aggregated across services.
  */
 export function getLogger(): LoggerService {
     if (!rootLogger) {
@@ -33,3 +34,24 @@ export function getLogger(): LoggerService {
     }
     return rootLogger;
 }
+
+/**
+ * Pre-bound logger for the HTTP API layer (controllers and the services that
+ * back them). Route files should narrow further with `.child({ route: '...' })`.
+ */
+export const apiLogger = getLogger().child({ module: 'api' });
+
+/** Pre-bound logger for the authentication layer (API-key validation, middleware). */
+export const authLogger = getLogger().child({ module: 'auth' });
+
+/** Pre-bound logger for the cryptography layer (digest + encryption). */
+export const cryptoLogger = getLogger().child({ module: 'crypto' });
+
+/** Pre-bound logger for the storage layer. Adapters should narrow with `.child({ adapter: '...' })`. */
+export const storageLogger = getLogger().child({ module: 'storage' });
+
+/** Pre-bound logger for runtime configuration parsing. */
+export const configLogger = getLogger().child({ module: 'config' });
+
+/** Pre-bound logger for the server entry point (startup / shutdown / validation). */
+export const serverLogger = getLogger().child({ module: 'server' });

--- a/src/services/logging/index.ts
+++ b/src/services/logging/index.ts
@@ -1,0 +1,35 @@
+import { PinoLoggerAdapter, registerRequestContextProvider } from './pino-adapter';
+import { getRequestContext } from './request-context';
+import type { LogLevel, LoggerConfig, LoggerService } from './types';
+
+export type { LogContext, LogLevel, LoggerConfig, LoggerService } from './types';
+export { getRequestContext, runWithRequestContext, updateRequestContext } from './request-context';
+export { registerRequestContextProvider } from './pino-adapter';
+
+/**
+ * Build a configured `LoggerService`. The first call to this in the process
+ * lifetime also wires the request-context provider so module-scope loggers
+ * pick up per-request fields (e.g. `correlationId`) automatically.
+ */
+export function createLogger(config: LoggerConfig = {}): LoggerService {
+    registerRequestContextProvider(() => getRequestContext());
+    return new PinoLoggerAdapter(config);
+}
+
+let rootLogger: LoggerService | undefined;
+
+/**
+ * Returns the process-wide root logger, instantiating it on first access from
+ * `LOG_LEVEL` / `LOG_PRETTY` environment variables. Modules that need a logger
+ * should call this and (optionally) attach a `child` binding with their name
+ * so log lines self-identify in aggregation.
+ */
+export function getLogger(): LoggerService {
+    if (!rootLogger) {
+        rootLogger = createLogger({
+            level: (process.env.LOG_LEVEL as LogLevel | undefined) ?? 'info',
+            pretty: process.env.LOG_PRETTY === 'true',
+        });
+    }
+    return rootLogger;
+}

--- a/src/services/logging/pino-adapter.ts
+++ b/src/services/logging/pino-adapter.ts
@@ -1,0 +1,88 @@
+import pino from 'pino';
+import type { LoggerService, LogContext, LoggerConfig } from './types';
+
+type RequestContextProvider = () => Record<string, unknown> | undefined;
+
+let requestContextProvider: RequestContextProvider | undefined;
+
+/**
+ * Register a function that supplies the current request context for log
+ * enrichment. Invoked by Pino's mixin on every log call, so module-scope
+ * loggers automatically pick up per-request fields such as `correlationId`.
+ */
+export function registerRequestContextProvider(fn: RequestContextProvider): void {
+    requestContextProvider = fn;
+}
+
+export class PinoLoggerAdapter implements LoggerService {
+    private readonly logger: pino.Logger;
+
+    constructor(configOrLogger?: LoggerConfig | pino.Logger) {
+        if (configOrLogger && typeof configOrLogger === 'object' && 'child' in configOrLogger) {
+            this.logger = configOrLogger;
+            return;
+        }
+
+        const config = (configOrLogger as LoggerConfig | undefined) ?? {};
+        this.logger = pino({
+            level: config.level ?? process.env.LOG_LEVEL ?? 'info',
+            mixin() {
+                if (!requestContextProvider) return {};
+                try {
+                    const context = requestContextProvider();
+                    return context ? { ...context } : {};
+                } catch (err) {
+                    // Mixin must never throw; falling back to an empty object is the
+                    // safest way to keep logging working when context wiring is broken.
+                    return { logMixinError: err instanceof Error ? err.message : String(err) };
+                }
+            },
+            ...(config.pretty && {
+                transport: {
+                    target: 'pino-pretty',
+                    options: {
+                        colorize: true,
+                        translateTime: 'SYS:standard',
+                        ignore: 'pid,hostname',
+                    },
+                },
+            }),
+        });
+    }
+
+    debug(msgOrObj: string | LogContext, msg?: string): void {
+        if (typeof msgOrObj === 'string') {
+            this.logger.debug(msgOrObj);
+        } else {
+            this.logger.debug(msgOrObj, msg);
+        }
+    }
+
+    info(msgOrObj: string | LogContext, msg?: string): void {
+        if (typeof msgOrObj === 'string') {
+            this.logger.info(msgOrObj);
+        } else {
+            this.logger.info(msgOrObj, msg);
+        }
+    }
+
+    warn(msgOrObj: string | LogContext, msg?: string): void {
+        if (typeof msgOrObj === 'string') {
+            this.logger.warn(msgOrObj);
+        } else {
+            this.logger.warn(msgOrObj, msg);
+        }
+    }
+
+    error(msgOrObj: string | LogContext, msg?: string): void {
+        if (typeof msgOrObj === 'string') {
+            this.logger.error(msgOrObj);
+        } else {
+            this.logger.error(msgOrObj, msg);
+        }
+    }
+
+    child(bindings: LogContext): LoggerService {
+        return new PinoLoggerAdapter(this.logger.child(bindings));
+    }
+}

--- a/src/services/logging/pino-adapter.ts
+++ b/src/services/logging/pino-adapter.ts
@@ -26,6 +26,13 @@ export class PinoLoggerAdapter implements LoggerService {
         const config = (configOrLogger as LoggerConfig | undefined) ?? {};
         this.logger = pino({
             level: config.level ?? process.env.LOG_LEVEL ?? 'info',
+            // Register Pino's standard error serializer under both common keys.
+            // Callers can pass `logger.error({ err: someError }, '...')` (or `error`)
+            // and Pino captures `message`, `stack`, `code`, `cause` as nested fields.
+            serializers: {
+                err: pino.stdSerializers.err,
+                error: pino.stdSerializers.err,
+            },
             mixin() {
                 if (!requestContextProvider) return {};
                 try {
@@ -79,6 +86,14 @@ export class PinoLoggerAdapter implements LoggerService {
             this.logger.error(msgOrObj);
         } else {
             this.logger.error(msgOrObj, msg);
+        }
+    }
+
+    fatal(msgOrObj: string | LogContext, msg?: string): void {
+        if (typeof msgOrObj === 'string') {
+            this.logger.fatal(msgOrObj);
+        } else {
+            this.logger.fatal(msgOrObj, msg);
         }
     }
 

--- a/src/services/logging/request-context.test.ts
+++ b/src/services/logging/request-context.test.ts
@@ -1,0 +1,45 @@
+import { getRequestContext, runWithRequestContext, updateRequestContext } from './request-context';
+
+describe('request context', () => {
+    it('returns undefined outside of any context', () => {
+        expect(getRequestContext()).toBeUndefined();
+    });
+
+    it('exposes the correlationId inside runWithRequestContext', () => {
+        runWithRequestContext('abc-123', () => {
+            expect(getRequestContext()?.correlationId).toBe('abc-123');
+        });
+    });
+
+    it('merges additional fields via updateRequestContext', () => {
+        runWithRequestContext('abc-123', () => {
+            updateRequestContext({ requestId: 'r-1', userId: 'u-9' });
+            const ctx = getRequestContext();
+            expect(ctx?.correlationId).toBe('abc-123');
+            expect(ctx?.requestId).toBe('r-1');
+            expect(ctx?.userId).toBe('u-9');
+        });
+    });
+
+    it('isolates contexts across separate runs', () => {
+        let outer: string | undefined;
+        let inner: string | undefined;
+
+        runWithRequestContext('outer-id', () => {
+            outer = getRequestContext()?.correlationId;
+            runWithRequestContext('inner-id', () => {
+                inner = getRequestContext()?.correlationId;
+            });
+            // The outer context survives the nested run.
+            expect(getRequestContext()?.correlationId).toBe('outer-id');
+        });
+
+        expect(outer).toBe('outer-id');
+        expect(inner).toBe('inner-id');
+    });
+
+    it('updateRequestContext is a no-op outside a context', () => {
+        expect(() => updateRequestContext({ anyKey: 'anyValue' })).not.toThrow();
+        expect(getRequestContext()).toBeUndefined();
+    });
+});

--- a/src/services/logging/request-context.ts
+++ b/src/services/logging/request-context.ts
@@ -1,0 +1,36 @@
+import { AsyncLocalStorage } from 'async_hooks';
+
+interface RequestContext {
+    correlationId: string;
+    [key: string]: unknown;
+}
+
+const asyncLocalStorage = new AsyncLocalStorage<RequestContext>();
+
+/**
+ * Returns the current request context, or undefined if called outside a context.
+ * Always carries `correlationId` when present; additional fields are whatever
+ * `updateRequestContext` has merged in.
+ */
+export function getRequestContext(): RequestContext | undefined {
+    return asyncLocalStorage.getStore();
+}
+
+/**
+ * Merges the provided partial into the current request context.
+ * No-op if called outside a context (does not throw).
+ */
+export function updateRequestContext(partial: Record<string, unknown>): void {
+    const store = asyncLocalStorage.getStore();
+    if (store) {
+        Object.assign(store, partial);
+    }
+}
+
+/**
+ * Runs the callback within a new request context. The correlationId is required;
+ * additional fields can be added progressively via `updateRequestContext`.
+ */
+export function runWithRequestContext<R>(correlationId: string, callback: () => R): R {
+    return asyncLocalStorage.run({ correlationId }, callback);
+}

--- a/src/services/logging/types.ts
+++ b/src/services/logging/types.ts
@@ -1,0 +1,26 @@
+export interface LogContext {
+    [key: string]: unknown;
+}
+
+export interface LoggerService {
+    debug(msg: string): void;
+    debug(obj: LogContext, msg?: string): void;
+
+    info(msg: string): void;
+    info(obj: LogContext, msg?: string): void;
+
+    warn(msg: string): void;
+    warn(obj: LogContext, msg?: string): void;
+
+    error(msg: string): void;
+    error(obj: LogContext, msg?: string): void;
+
+    child(bindings: LogContext): LoggerService;
+}
+
+export type LogLevel = 'debug' | 'info' | 'warn' | 'error';
+
+export interface LoggerConfig {
+    level?: LogLevel;
+    pretty?: boolean;
+}

--- a/src/services/logging/types.ts
+++ b/src/services/logging/types.ts
@@ -15,10 +15,17 @@ export interface LoggerService {
     error(msg: string): void;
     error(obj: LogContext, msg?: string): void;
 
+    /**
+     * Fatal-level log. Use immediately before exiting the process on an
+     * unrecoverable startup error so operators can find the cause in logs.
+     */
+    fatal(msg: string): void;
+    fatal(obj: LogContext, msg?: string): void;
+
     child(bindings: LogContext): LoggerService;
 }
 
-export type LogLevel = 'debug' | 'info' | 'warn' | 'error';
+export type LogLevel = 'debug' | 'info' | 'warn' | 'error' | 'fatal';
 
 export interface LoggerConfig {
     level?: LogLevel;

--- a/src/services/storage/aws.ts
+++ b/src/services/storage/aws.ts
@@ -8,10 +8,10 @@ import {
     DeleteObjectCommand,
 } from '@aws-sdk/client-s3';
 import { IStorageService } from '.';
-import { getLogger } from '../logging';
-
-const logger = getLogger();
+import { storageLogger } from '../logging';
 import { S3_REGION, S3_ENDPOINT, S3_FORCE_PATH_STYLE, generatePublicUri } from '../../config';
+
+const logger = storageLogger.child({ adapter: 'aws' });
 
 /**
  * Creates the S3 client configuration.

--- a/src/services/storage/aws.ts
+++ b/src/services/storage/aws.ts
@@ -98,10 +98,7 @@ export class AWSStorageService implements IStorageService {
             logger.info({ bucket, key }, '[AWSStorageService.uploadFile] File uploaded successfully');
             return { uri: generateUri(bucket, key) };
         } catch (error) {
-            logger.error(
-                { bucket, key, err: error instanceof Error ? error.message : error },
-                '[AWSStorageService.uploadFile] Error uploading file',
-            );
+            logger.error({ bucket, key, err: error }, '[AWSStorageService.uploadFile] Error uploading file');
             throw error;
         }
     }
@@ -144,7 +141,7 @@ export class AWSStorageService implements IStorageService {
             return (response.Contents || []).map((obj) => obj.Key!).filter(Boolean);
         } catch (error) {
             logger.error(
-                { bucket, prefix, err: error instanceof Error ? error.message : error },
+                { bucket, prefix, err: error },
                 '[AWSStorageService.listObjectsByPrefix] Error listing objects',
             );
             throw error;
@@ -166,10 +163,7 @@ export class AWSStorageService implements IStorageService {
             await this.storage.send(command);
             logger.info({ bucket, key }, '[AWSStorageService.deleteFile] File deleted successfully');
         } catch (error) {
-            logger.error(
-                { bucket, key, err: error instanceof Error ? error.message : error },
-                '[AWSStorageService.deleteFile] Error deleting file',
-            );
+            logger.error({ bucket, key, err: error }, '[AWSStorageService.deleteFile] Error deleting file');
             throw error;
         }
     }

--- a/src/services/storage/aws.ts
+++ b/src/services/storage/aws.ts
@@ -8,6 +8,9 @@ import {
     DeleteObjectCommand,
 } from '@aws-sdk/client-s3';
 import { IStorageService } from '.';
+import { getLogger } from '../logging';
+
+const logger = getLogger();
 import { S3_REGION, S3_ENDPOINT, S3_FORCE_PATH_STYLE, generatePublicUri } from '../../config';
 
 /**
@@ -92,10 +95,13 @@ export class AWSStorageService implements IStorageService {
         try {
             const command = new PutObjectCommand(params);
             await this.storage.send(command);
-            console.log(`File uploaded successfully to ${bucket}/${key}`);
+            logger.info({ bucket, key }, '[AWSStorageService.uploadFile] File uploaded successfully');
             return { uri: generateUri(bucket, key) };
         } catch (error) {
-            console.error(`Error uploading file: ${error}`);
+            logger.error(
+                { bucket, key, err: error instanceof Error ? error.message : error },
+                '[AWSStorageService.uploadFile] Error uploading file',
+            );
             throw error;
         }
     }
@@ -137,7 +143,10 @@ export class AWSStorageService implements IStorageService {
             const response = await this.storage.send(command);
             return (response.Contents || []).map((obj) => obj.Key!).filter(Boolean);
         } catch (error) {
-            console.error(`Error listing objects with prefix ${prefix}: ${error}`);
+            logger.error(
+                { bucket, prefix, err: error instanceof Error ? error.message : error },
+                '[AWSStorageService.listObjectsByPrefix] Error listing objects',
+            );
             throw error;
         }
     }
@@ -155,9 +164,12 @@ export class AWSStorageService implements IStorageService {
 
         try {
             await this.storage.send(command);
-            console.log(`File deleted successfully from ${bucket}/${key}`);
+            logger.info({ bucket, key }, '[AWSStorageService.deleteFile] File deleted successfully');
         } catch (error) {
-            console.error(`Error deleting file: ${error}`);
+            logger.error(
+                { bucket, key, err: error instanceof Error ? error.message : error },
+                '[AWSStorageService.deleteFile] Error deleting file',
+            );
             throw error;
         }
     }

--- a/yarn.lock
+++ b/yarn.lock
@@ -2075,6 +2075,11 @@
   dependencies:
     "@noble/hashes" "^1.1.5"
 
+"@pinojs/redact@^0.4.0":
+  version "0.4.0"
+  resolved "https://registry.yarnpkg.com/@pinojs/redact/-/redact-0.4.0.tgz#c3de060dd12640dcc838516aa2a6803cc7b2e9d6"
+  integrity sha512-k2ENnmBugE/rzQfEcdWHcCY+/FM3VLzH9cYEsbdsoqrvzAKRhUZeRNhAZvB8OitQJ1TBed3yqWtdjzS6wJKBwg==
+
 "@protobufjs/aspromise@^1.1.1", "@protobufjs/aspromise@^1.1.2":
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/@protobufjs/aspromise/-/aspromise-1.1.2.tgz#9b8b0cc663d669a7d8f6f5d0893a14d348f30fbf"
@@ -3706,6 +3711,11 @@ asynckit@^0.4.0:
   resolved "https://registry.yarnpkg.com/asynckit/-/asynckit-0.4.0.tgz#c79ed97f7f34cb8f2ba1bc9790bcc366474b4b79"
   integrity sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==
 
+atomic-sleep@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/atomic-sleep/-/atomic-sleep-1.0.0.tgz#eb85b77a601fc932cfe432c5acd364a9e2c9075b"
+  integrity sha512-kNOjDqAh7px0XWNI+4QbzoiR/nTkHAWNud2uvnJquD1/x5a7EQZMJT0AczqK0Qn67oY/TTQ1LbUKajZpp3I9tQ==
+
 available-typed-arrays@^1.0.7:
   version "1.0.7"
   resolved "https://registry.yarnpkg.com/available-typed-arrays/-/available-typed-arrays-1.0.7.tgz#a5cc375d6a03c2efc87a553f3e0b1522def14846"
@@ -4176,7 +4186,7 @@ colorette@^1.2.0:
   resolved "https://registry.yarnpkg.com/colorette/-/colorette-1.4.0.tgz#5190fbb87276259a86ad700bff2c6d6faa3fca40"
   integrity sha512-Y2oEozpomLn7Q3HFP7dpww7AtMJplbM9lGZP6RDfHqmbeRjiwRg4n6VM6j4KLmRke85uWEI7JqF17f3pqdRA0g==
 
-colorette@^2.0.14, colorette@^2.0.20:
+colorette@^2.0.14, colorette@^2.0.20, colorette@^2.0.7:
   version "2.0.20"
   resolved "https://registry.yarnpkg.com/colorette/-/colorette-2.0.20.tgz#9eb793e6833067f7235902fcd3b09917a000a95a"
   integrity sha512-IfEDxwoWIjkeXL1eXcDiow4UbKjhLdq6/EuSVR9GMN7KVH3r9gQ83e73hsz1Nd1T3ijd5xv1wcWRYO+D6kCI2w==
@@ -4388,6 +4398,11 @@ data-view-byte-offset@^1.0.1:
     call-bound "^1.0.2"
     es-errors "^1.3.0"
     is-data-view "^1.0.1"
+
+dateformat@^4.6.3:
+  version "4.6.3"
+  resolved "https://registry.yarnpkg.com/dateformat/-/dateformat-4.6.3.tgz#556fa6497e5217fedb78821424f8a1c22fa3f4b5"
+  integrity sha512-2P0p0pFGzHS5EMnhdxQi7aJN+iMheud0UhG4dlE1DLAlvL8JHjJJTX/CSm4JXwV0Ka5nGk3zC5mcb5bUQUxxMA==
 
 debug@2.6.9:
   version "2.6.9"
@@ -4638,7 +4653,7 @@ encodeurl@~2.0.0:
   resolved "https://registry.yarnpkg.com/encodeurl/-/encodeurl-2.0.0.tgz#7b8ea898077d7e409d3ac45474ea38eaf0857a58"
   integrity sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg==
 
-end-of-stream@^1.4.1:
+end-of-stream@^1.1.0, end-of-stream@^1.4.1:
   version "1.4.5"
   resolved "https://registry.yarnpkg.com/end-of-stream/-/end-of-stream-1.4.5.tgz#7344d711dea40e0b74abc2ed49778743ccedb08c"
   integrity sha512-ooEGc6HP26xXq/N+GCGOT0JKCLDGrq2bQUZrQ7gyrJiZANJ/8YDTxTpQBXGMn+WbIQXNVpyWymm7KYVICQnyOg==
@@ -5006,6 +5021,11 @@ extend@^3.0.2:
   version "3.0.2"
   resolved "https://registry.yarnpkg.com/extend/-/extend-3.0.2.tgz#f8b1136b4071fbd8eb140aff858b1019ec2915fa"
   integrity sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==
+
+fast-copy@^4.0.0:
+  version "4.0.3"
+  resolved "https://registry.yarnpkg.com/fast-copy/-/fast-copy-4.0.3.tgz#935adef81c26276dcbe8892347af307b5090206a"
+  integrity sha512-58apWr0GUiDFM8+3afrO6eYwJBn9ZAhDOzG3L+/9llab/haCARS2UIfffmOurYLwbgDRs8n0rfr6qAAPEAuAQw==
 
 fast-deep-equal@^3.1.1, fast-deep-equal@^3.1.3:
   version "3.1.3"
@@ -5532,6 +5552,11 @@ hasown@^2.0.2:
   integrity sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==
   dependencies:
     function-bind "^1.1.2"
+
+help-me@^5.0.0:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/help-me/-/help-me-5.0.0.tgz#b1ebe63b967b74060027c2ac61f9be12d354a6f6"
+  integrity sha512-7xgomUX6ADmcYzFik0HzAxh/73YlKR9bmFzf51CZwR+b6YtzU2m0u49hQCqV6SvlqIqsaxovfwdvbnsw3b/zpg==
 
 hmac-drbg@^1.0.1:
   version "1.0.1"
@@ -6371,6 +6396,11 @@ jose@^5.9.3:
   resolved "https://registry.yarnpkg.com/jose/-/jose-5.10.0.tgz#c37346a099d6467c401351a9a0c2161e0f52c4be"
   integrity sha512-s+3Al/p9g32Iq+oqXxkW//7jk2Vig6FF1CFqzVXoTUXt2qz89YWbL+OwS17NFYEvxC35n0FKeGO2LGYSxeM2Gg==
 
+joycon@^3.1.1:
+  version "3.1.1"
+  resolved "https://registry.yarnpkg.com/joycon/-/joycon-3.1.1.tgz#bce8596d6ae808f8b68168f5fc69280996894f03"
+  integrity sha512-34wB/Y7MW7bzjKRjUKTa46I2Z7eV62Rkhva+KkopW7Qvv/OSWBqvkSY7vusOPrNuZcUG3tApvdVgNB8POj3SPw==
+
 js-levenshtein@^1.1.6:
   version "1.1.6"
   resolved "https://registry.yarnpkg.com/js-levenshtein/-/js-levenshtein-1.1.6.tgz#c6cee58eb3550372df8deb85fad5ce66ce01d59d"
@@ -7108,6 +7138,11 @@ object.assign@^4.1.7:
     has-symbols "^1.1.0"
     object-keys "^1.1.1"
 
+on-exit-leak-free@^2.1.0:
+  version "2.1.2"
+  resolved "https://registry.yarnpkg.com/on-exit-leak-free/-/on-exit-leak-free-2.1.2.tgz#fed195c9ebddb7d9e4c3842f93f281ac8dadd3b8"
+  integrity sha512-0eJJY6hXLGf1udHwfNftBqH+g73EU4B504nZeKpz1sYRKafAghwxEJunB2O7rDZkL4PGfsMVnTXZ2EjibbqcsA==
+
 on-finished@~2.4.1:
   version "2.4.1"
   resolved "https://registry.yarnpkg.com/on-finished/-/on-finished-2.4.1.tgz#58c8c44116e54845ad57f14ab10b03533184ac3f"
@@ -7115,7 +7150,7 @@ on-finished@~2.4.1:
   dependencies:
     ee-first "1.1.1"
 
-once@^1.3.0, once@^1.4.0:
+once@^1.3.0, once@^1.3.1, once@^1.4.0:
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/once/-/once-1.4.0.tgz#583b1aa775961d4b113ac17d9c50baef9dd76bd1"
   integrity sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==
@@ -7345,6 +7380,54 @@ pify@^3.0.0:
   resolved "https://registry.yarnpkg.com/pify/-/pify-3.0.0.tgz#e5a4acd2c101fdf3d9a4d07f0dbc4db49dd28176"
   integrity sha512-C3FsVNH1udSEX48gGX1xfvwTWfsYWj5U+8/uK15BGzIGrKoUpghX8hWZwa/OFnakBiiVNmBvemTJR5mcy7iPcg==
 
+pino-abstract-transport@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/pino-abstract-transport/-/pino-abstract-transport-3.0.0.tgz#b21e5f33a297e8c4c915c62b3ce5dd4a87a52c23"
+  integrity sha512-wlfUczU+n7Hy/Ha5j9a/gZNy7We5+cXp8YL+X+PG8S0KXxw7n/JXA3c46Y0zQznIJ83URJiwy7Lh56WLokNuxg==
+  dependencies:
+    split2 "^4.0.0"
+
+pino-pretty@^13.1.3:
+  version "13.1.3"
+  resolved "https://registry.yarnpkg.com/pino-pretty/-/pino-pretty-13.1.3.tgz#2274cccda925dd355c104079a5029f6598d0381b"
+  integrity sha512-ttXRkkOz6WWC95KeY9+xxWL6AtImwbyMHrL1mSwqwW9u+vLp/WIElvHvCSDg0xO/Dzrggz1zv3rN5ovTRVowKg==
+  dependencies:
+    colorette "^2.0.7"
+    dateformat "^4.6.3"
+    fast-copy "^4.0.0"
+    fast-safe-stringify "^2.1.1"
+    help-me "^5.0.0"
+    joycon "^3.1.1"
+    minimist "^1.2.6"
+    on-exit-leak-free "^2.1.0"
+    pino-abstract-transport "^3.0.0"
+    pump "^3.0.0"
+    secure-json-parse "^4.0.0"
+    sonic-boom "^4.0.1"
+    strip-json-comments "^5.0.2"
+
+pino-std-serializers@^7.0.0:
+  version "7.1.0"
+  resolved "https://registry.yarnpkg.com/pino-std-serializers/-/pino-std-serializers-7.1.0.tgz#a7b0cd65225f29e92540e7853bd73b07479893fc"
+  integrity sha512-BndPH67/JxGExRgiX1dX0w1FvZck5Wa4aal9198SrRhZjH3GxKQUKIBnYJTdj2HDN3UQAS06HlfcSbQj2OHmaw==
+
+pino@^10.3.1:
+  version "10.3.1"
+  resolved "https://registry.yarnpkg.com/pino/-/pino-10.3.1.tgz#6552c8f8d8481844c9e452e7bf0be90bff1939ce"
+  integrity sha512-r34yH/GlQpKZbU1BvFFqOjhISRo1MNx1tWYsYvmj6KIRHSPMT2+yHOEb1SG6NMvRoHRF0a07kCOox/9yakl1vg==
+  dependencies:
+    "@pinojs/redact" "^0.4.0"
+    atomic-sleep "^1.0.0"
+    on-exit-leak-free "^2.1.0"
+    pino-abstract-transport "^3.0.0"
+    pino-std-serializers "^7.0.0"
+    process-warning "^5.0.0"
+    quick-format-unescaped "^4.0.3"
+    real-require "^0.2.0"
+    safe-stable-stringify "^2.3.1"
+    sonic-boom "^4.0.1"
+    thread-stream "^4.0.0"
+
 pirates@^4.0.4:
   version "4.0.7"
   resolved "https://registry.yarnpkg.com/pirates/-/pirates-4.0.7.tgz#643b4a18c4257c8a65104b73f3049ce9a0a15e22"
@@ -7419,6 +7502,11 @@ prismjs@^1.29.0:
   resolved "https://registry.yarnpkg.com/prismjs/-/prismjs-1.30.0.tgz#d9709969d9d4e16403f6f348c63553b19f0975a9"
   integrity sha512-DEvV2ZF2r2/63V+tK8hQvrR2ZGn10srHbXviTlcv7Kpzw8jWiNTqbVgjO3IY8RxrrOUF8VPMQQFysYYYv0YZxw==
 
+process-warning@^5.0.0:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/process-warning/-/process-warning-5.0.0.tgz#566e0bf79d1dff30a72d8bbbe9e8ecefe8d378d7"
+  integrity sha512-a39t9ApHNx2L4+HBnQKqxxHNs1r7KF+Intd8Q/g1bUh6q0WIp9voPXJ/x0j+ZL45KF1pJd9+q2jLIRMfvEshkA==
+
 prompts@^2.0.1:
   version "2.4.2"
   resolved "https://registry.yarnpkg.com/prompts/-/prompts-2.4.2.tgz#7b57e73b3a48029ad10ebd44f74b01722a4cb069"
@@ -7472,6 +7560,14 @@ pstree.remy@^1.1.8:
   resolved "https://registry.yarnpkg.com/pstree.remy/-/pstree.remy-1.1.8.tgz#c242224f4a67c21f686839bbdb4ac282b8373d3a"
   integrity sha512-77DZwxQmxKnu3aR542U+X8FypNzbfJ+C5XQDk3uWjWxn6151aIMGthWYRXTqT1E5oJvg+ljaa2OJi+VfvCOQ8w==
 
+pump@^3.0.0:
+  version "3.0.4"
+  resolved "https://registry.yarnpkg.com/pump/-/pump-3.0.4.tgz#1f313430527fa8b905622ebd22fe1444e757ab3c"
+  integrity sha512-VS7sjc6KR7e1ukRFhQSY5LM2uBWAUPiOPa/A3mkKmiMwSmRFUITt0xuj+/lesgnCv+dPIEYlkzrcyXgquIHMcA==
+  dependencies:
+    end-of-stream "^1.1.0"
+    once "^1.3.1"
+
 punycode@^2.1.0:
   version "2.3.1"
   resolved "https://registry.yarnpkg.com/punycode/-/punycode-2.3.1.tgz#027422e2faec0b25e1549c3e1bd8309b9133b6e5"
@@ -7493,6 +7589,11 @@ queue-microtask@^1.2.2:
   version "1.2.3"
   resolved "https://registry.yarnpkg.com/queue-microtask/-/queue-microtask-1.2.3.tgz#4929228bbc724dfac43e0efb058caf7b6cfb6243"
   integrity sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==
+
+quick-format-unescaped@^4.0.3:
+  version "4.0.4"
+  resolved "https://registry.yarnpkg.com/quick-format-unescaped/-/quick-format-unescaped-4.0.4.tgz#93ef6dd8d3453cbc7970dd614fad4c5954d6b5a7"
+  integrity sha512-tYC1Q1hgyRuHgloV/YXs2w15unPVh8qfu/qCTfhTYamaw7fyhumKa2yGpdSo87vY32rIclj+4fWYQXUMs9EHvg==
 
 randombytes@^2.1.0:
   version "2.1.0"
@@ -7577,6 +7678,16 @@ readdirp@~3.6.0:
   integrity sha512-hOS089on8RduqdbhvQ5Z37A0ESjsqz6qnRcffsMU3495FuTdqSm+7bhJ29JvIOsBDEEnan5DPu9t3To9VRlMzA==
   dependencies:
     picomatch "^2.2.1"
+
+real-require@^0.2.0:
+  version "0.2.0"
+  resolved "https://registry.yarnpkg.com/real-require/-/real-require-0.2.0.tgz#209632dea1810be2ae063a6ac084fee7e33fba78"
+  integrity sha512-57frrGM/OCTLqLOAh0mhVA9VBMHd+9U7Zb2THMGdBUoZVOtGbJzjxsYGDJ3A9AYYCP4hn6y1TVbaOfzWtm5GFg==
+
+real-require@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/real-require/-/real-require-1.0.0.tgz#e4f0a3737e8060c513b60c2652c58b8ef56bc8a9"
+  integrity sha512-P4nbQYQfePJxRSmY+v/KINxVucm4NF3p3s7pJveMTtom52FR4YGltUQLB8idDXwDDWW+eYrWDFbuzUnjoWHF7g==
 
 rechoir@^0.8.0:
   version "0.8.0"
@@ -7804,6 +7915,11 @@ safe-regex-test@^1.1.0:
     es-errors "^1.3.0"
     is-regex "^1.2.1"
 
+safe-stable-stringify@^2.3.1:
+  version "2.5.0"
+  resolved "https://registry.yarnpkg.com/safe-stable-stringify/-/safe-stable-stringify-2.5.0.tgz#4ca2f8e385f2831c432a719b108a3bf7af42a1dd"
+  integrity sha512-b3rppTKm9T+PsVCBEOUR46GWI7fdOs00VKZ1+9c1EWDaDMvjQc6tUwuFyIprgGgTcWoVHSKrU8H31ZHA2e0RHA==
+
 "safer-buffer@>= 2.1.2 < 3":
   version "2.1.2"
   resolved "https://registry.yarnpkg.com/safer-buffer/-/safer-buffer-2.1.2.tgz#44fa161b0187b9549dd84bb91802f9bd8385cd6a"
@@ -7823,6 +7939,11 @@ schema-utils@^4.0.0, schema-utils@^4.2.0, schema-utils@^4.3.0, schema-utils@^4.3
     ajv "^8.9.0"
     ajv-formats "^2.1.1"
     ajv-keywords "^5.1.0"
+
+secure-json-parse@^4.0.0:
+  version "4.1.0"
+  resolved "https://registry.yarnpkg.com/secure-json-parse/-/secure-json-parse-4.1.0.tgz#4f1ab41c67a13497ea1b9131bb4183a22865477c"
+  integrity sha512-l4KnYfEyqYJxDwlNVyRfO2E4NTHfMKAWdUuA8J0yve2Dz/E/PdBepY03RvyJpssIpRFwJoCD55wA+mEDs6ByWA==
 
 "semver@2 || 3 || 4 || 5", semver@^5.5.0:
   version "5.7.2"
@@ -8102,6 +8223,13 @@ slugify@~1.4.7:
   resolved "https://registry.yarnpkg.com/slugify/-/slugify-1.4.7.tgz#e42359d505afd84a44513280868e31202a79a628"
   integrity sha512-tf+h5W1IrjNm/9rKKj0JU2MDMruiopx0jjVA5zCdBtcGjfp0+c5rHw/zADLC3IeKlGHtVbHtpfzvYA0OYT+HKg==
 
+sonic-boom@^4.0.1:
+  version "4.2.1"
+  resolved "https://registry.yarnpkg.com/sonic-boom/-/sonic-boom-4.2.1.tgz#28598250df4899c0ac572d7e2f0460690ba6a030"
+  integrity sha512-w6AxtubXa2wTXAUsZMMWERrsIRAdrK0Sc+FUytWvYAhBJLyuI4llrMIC1DtlNSdI99EI86KZum2MMq3EAZlF9Q==
+  dependencies:
+    atomic-sleep "^1.0.0"
+
 source-map-js@^1.2.1:
   version "1.2.1"
   resolved "https://registry.yarnpkg.com/source-map-js/-/source-map-js-1.2.1.tgz#1ce5650fddd87abc099eda37dcff024c2667ae46"
@@ -8158,6 +8286,11 @@ spdx-license-ids@^3.0.0:
   version "3.0.22"
   resolved "https://registry.yarnpkg.com/spdx-license-ids/-/spdx-license-ids-3.0.22.tgz#abf5a08a6f5d7279559b669f47f0a43e8f3464ef"
   integrity sha512-4PRT4nh1EImPbt2jASOKHX7PB7I+e4IWNLvkKFDxNhJlfjbYlleYQh285Z/3mPTHSAK/AvdMmw5BNNuYH8ShgQ==
+
+split2@^4.0.0:
+  version "4.2.0"
+  resolved "https://registry.yarnpkg.com/split2/-/split2-4.2.0.tgz#c9c5920904d148bab0b9f67145f245a86aadbfa4"
+  integrity sha512-UcjcJOWknrNkF6PLX83qcHM6KHgVKNkV62Y8a5uYDVv9ydGQVwAHMKqHdJje1VTWpljG0WYpCDhrCdAOYH4TWg==
 
 sprintf-js@~1.0.2:
   version "1.0.3"
@@ -8328,6 +8461,11 @@ strip-json-comments@^3.1.1:
   resolved "https://registry.yarnpkg.com/strip-json-comments/-/strip-json-comments-3.1.1.tgz#31f1281b3832630434831c310c01cccda8cbe006"
   integrity sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==
 
+strip-json-comments@^5.0.2:
+  version "5.0.3"
+  resolved "https://registry.yarnpkg.com/strip-json-comments/-/strip-json-comments-5.0.3.tgz#b7304249dd402ee67fd518ada993ab3593458bcf"
+  integrity sha512-1tB5mhVo7U+ETBKNf92xT4hrQa3pm0MZ0PQvuDnWgAAGHDsfp4lPSpiS6psrSiet87wyGPh9ft6wmhOMQ0hDiw==
+
 strnum@^1.1.1:
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/strnum/-/strnum-1.1.2.tgz#57bca4fbaa6f271081715dbc9ed7cee5493e28e4"
@@ -8494,6 +8632,13 @@ text-table@^0.2.0:
   version "0.2.0"
   resolved "https://registry.yarnpkg.com/text-table/-/text-table-0.2.0.tgz#7f5ee823ae805207c00af2df4a84ec3fcfa570b4"
   integrity sha512-N+8UisAXDGk8PFXP4HAzVR9nbfmVJ3zYLAWiTIoqC5v5isinhr+r5uaO8+7r3BMfuNIufIsA7RdpVgacC2cSpw==
+
+thread-stream@^4.0.0:
+  version "4.2.0"
+  resolved "https://registry.yarnpkg.com/thread-stream/-/thread-stream-4.2.0.tgz#054063e93baab22363d05b784d6c7e439230cac7"
+  integrity sha512-e2zZ96wSChazBsbENf/Pcm/4swHt2cEKQ92rhUjkL9GCKiTDJIaTBenjE/m9DXi0QBmTMDkFDdOomUy20A1tDQ==
+  dependencies:
+    real-require "^1.0.0"
 
 tmpl@1.0.5:
   version "1.0.5"


### PR DESCRIPTION
This PR adopts structured Pino logging across the storage service with end-to-end correlation-ID propagation. Every log line carries the `correlationId` from the originating request, either an inbound `x-correlation-id` header (validated against length cap + charset) or a freshly minted UUID when the header is absent or malformed. The id is echoed on the response so upstream callers and humans can trace requests end-to-end.

All `console.error/warn/info/log` calls in `src/` are replaced with the centralised logger; error context (algorithm, paths, bucket/key, byte counts) now lives in structured fields. README documents the new `LOG_LEVEL` / `LOG_PRETTY` env vars and the correlation-ID propagation.

Inbound header validation (max 128 chars, charset `[A-Za-z0-9_-]`) blocks log poisoning, header smuggling, and control-character injection.

Closes #112

## Test plan
- [x] 223 unit tests pass (existing 212 + 11 new across middleware + request-context)
- [x] Webpack build clean
- [x] Lint 0 errors
- [ ] Docker e2e suite deferred to CI