### PR TITLE
chore(docker): prefix rolling main-build sha tag with main-

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -64,7 +64,7 @@ jobs:
                   images: ghcr.io/${{ github.repository }}
                   tags: |
                       type=raw,value=main,enable=${{ github.ref == 'refs/heads/main' }}
-                      type=sha,format=short,enable=${{ github.ref == 'refs/heads/main' }}
+                      type=sha,format=short,prefix=main-,enable=${{ github.ref == 'refs/heads/main' }}
                       type=match,pattern=v(.*),group=1,enable=${{ startsWith(github.ref, 'refs/tags/v') }}
                       type=raw,value=latest,enable=${{ startsWith(github.ref, 'refs/tags/v') && !contains(github.ref_name, '-rc') && !contains(github.ref_name, '-alpha') && !contains(github.ref_name, '-beta') && !contains(github.ref_name, '-pre') }}
                       type=raw,value=${{ inputs.version }},enable=${{ github.event_name == 'workflow_dispatch' && inputs.version != '' }}

--- a/RELEASE_MANAGEMENT_GUIDE.md
+++ b/RELEASE_MANAGEMENT_GUIDE.md
@@ -211,7 +211,7 @@ compile cleanly. Does not publish.
 Triggers on push to `main` and on `v<X.Y.Z>` tag pushes.
 
 - Push to `main`: builds and pushes `ghcr.io/uncefact/project-storage-service:main`
-  plus a `:sha-<short>` tag pinnable to the specific commit.
+  plus a `:main-<short-sha>` tag pinnable to the specific commit.
 - Tag push: builds and pushes `:<X.Y.Z>` (the semver value) and `:latest`
   (suppressed for `-rc`, `-alpha`, `-beta`, `-pre` suffixes).
 - `workflow_dispatch` with an explicit `version` input lets a maintainer

--- a/docs/adrs/003-trunk-based-tag-driven-release-flow.md
+++ b/docs/adrs/003-trunk-based-tag-driven-release-flow.md
@@ -33,7 +33,7 @@ Hotfixes branch from the relevant release tag, PR to `main`, and produce a new p
 - Release notes communicate user-facing impact. The human-written `RELEASE_NOTES.md` entry is the single artefact consumers read at the tagged commit; it is not constrained by what conventional-commit subjects happened to be in the diff.
 - Customising release behaviour is local. Changing how a release is cut is a workflow edit rather than a third-party action configuration.
 - Pipeline scope is honest. Build Docs only runs when docs change; the Docker workflow only runs when something that goes into the image changes. Less wasted CI, faster signal.
-- The Docker tag set is more useful day-to-day. Push to `main` produces both `:main` (rolling) and `:sha-<short>` (pinnable per commit), so an operator pulling from `main` can record exactly which build they ran.
+- The Docker tag set is more useful day-to-day. Push to `main` produces both `:main` (rolling) and `:main-<short-sha>` (pinnable per commit), so an operator pulling from `main` can record exactly which build they ran.
 
 **What becomes more difficult:**
 


### PR DESCRIPTION
Renames the per-commit Docker tag on pushes to `main` from `:sha-<short>` to `:main-<short>`. The new tag is self-identifying: an operator pulling `ghcr.io/uncefact/project-storage-service:main-251a89d` can see at a glance that it is a main-branch build at that commit, without cross-referencing the tag with the branch.

Release-tag images (`:4.0.0`, `:latest`) are unaffected; this only changes the rolling per-commit tag for `main`.

## Changes

- `.github/workflows/docker.yml` -- `type=sha,format=short` gains `prefix=main-` so the resulting tag is `main-<short-sha>` instead of the default `sha-<short-sha>`.
- `RELEASE_MANAGEMENT_GUIDE.md` -- docs reference updated.
- `docs/adrs/003-trunk-based-tag-driven-release-flow.md` -- consequences section updated to match the new tag shape.

## Test plan
- [x] `yarn test` 21 suites, 248 cases green.
- [x] Workflow YAML hand-checked against the `docker/metadata-action` `prefix` option.