### PR TITLE
docs: extend env examples with logging/OTel and relocate disk-space caution

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -40,3 +40,14 @@ AVAILABLE_BUCKETS=documents,files
 # File Upload Configuration
 # MAX_UPLOAD_SIZE=10485760
 # ALLOWED_UPLOAD_TYPES=image/png,image/jpeg,image/webp,application/pdf
+
+# Logging Configuration
+# LOG_LEVEL=info        # debug | info | warn | error | fatal
+# LOG_PRETTY=true       # Pretty-format logs via pino-pretty.
+                        # Defaults to on in NODE_ENV=development; leave unset in production.
+
+# OpenTelemetry Configuration (opt-in)
+# Set OTEL_EXPORTER_OTLP_ENDPOINT to enable tracing; the SDK does nothing when unset.
+# OTEL_EXPORTER_OTLP_ENDPOINT=http://localhost:4317
+# OTEL_SERVICE_NAME=storage-service
+# DEPLOYMENT_ENVIRONMENT=development   # development | production

--- a/documentation/docs/deployment-guide/configuration/index.md
+++ b/documentation/docs/deployment-guide/configuration/index.md
@@ -107,29 +107,57 @@ Resource attributes emitted by the service:
 Example `.env` file for local development:
 
 ```env
-# Server
+# Server Configuration
 PROTOCOL=http
 DOMAIN=localhost
 PORT=3333
 # EXTERNAL_PORT=443
 
 # Authentication (Required)
+# The API key used to authenticate upload requests
 API_KEY=your-secure-api-key-here
 
-# Storage
+# Storage Configuration
+# Options: local | gcp | aws
 STORAGE_TYPE=local
 LOCAL_DIRECTORY=uploads
 
-# Buckets
+# Bucket Configuration
+# DEFAULT_BUCKET is used as a fallback when a request does not include a bucket.
+# If unset, requests without a bucket will receive a 400 error.
 DEFAULT_BUCKET=documents
 AVAILABLE_BUCKETS=documents,files
 
-# Logging
-# LOG_LEVEL=info        # debug | info | warn | error | fatal
-# LOG_PRETTY=true       # Defaults to on in NODE_ENV=development
+# Public URL Override
+# When using a CDN or custom domain, override the base URL for document URIs returned to clients.
+# Uploads still go to the configured storage provider. Only the URI in API responses changes.
+# Applies to: aws, gcp (ignored for local storage)
+# PUBLIC_URL=https://cdn.example.com
 
-# OpenTelemetry (opt-in; SDK starts only when OTEL_EXPORTER_OTLP_ENDPOINT is set)
+# Cloud Provider Credentials (if using cloud storage)
+
+# Google Cloud Platform
+# GOOGLE_APPLICATION_CREDENTIALS=/path/to/service-account-file.json
+
+# AWS S3 / S3-Compatible Providers (MinIO, DigitalOcean Spaces, Cloudflare R2, etc.)
+# S3_REGION=ap-southeast-2           # Required for AWS S3, optional with custom endpoint
+# S3_ENDPOINT=http://localhost:9000  # Custom endpoint for S3-compatible providers
+# S3_FORCE_PATH_STYLE=true           # Required for MinIO, Cloudflare R2
+# AWS_ACCESS_KEY_ID=your-access-key-id
+# AWS_SECRET_ACCESS_KEY=your-secret-access-key
+
+# File Upload Configuration
+# MAX_UPLOAD_SIZE=10485760
+# ALLOWED_UPLOAD_TYPES=image/png,image/jpeg,image/webp,application/pdf
+
+# Logging Configuration
+# LOG_LEVEL=info        # debug | info | warn | error | fatal
+# LOG_PRETTY=true       # Pretty-format logs via pino-pretty.
+                        # Defaults to on in NODE_ENV=development; leave unset in production.
+
+# OpenTelemetry Configuration (opt-in)
+# Set OTEL_EXPORTER_OTLP_ENDPOINT to enable tracing; the SDK does nothing when unset.
 # OTEL_EXPORTER_OTLP_ENDPOINT=http://localhost:4317
 # OTEL_SERVICE_NAME=storage-service
-# DEPLOYMENT_ENVIRONMENT=development
+# DEPLOYMENT_ENVIRONMENT=development   # development | production
 ```

--- a/documentation/docs/deployment-guide/configuration/index.md
+++ b/documentation/docs/deployment-guide/configuration/index.md
@@ -50,6 +50,17 @@ For cloud storage provider configuration, see [Storage Providers](../storage-pro
 `MAX_UPLOAD_SIZE` governs the maximum size for both JSON request bodies and multipart file uploads.
 :::
 
+:::caution Disk space considerations for file uploads
+
+Uploaded files are temporarily written to the OS temp directory before being forwarded to storage. Temp files are automatically cleaned up after each upload completes or fails.
+
+When planning your deployment, ensure:
+
+- **Temp directory disk space** can accommodate concurrent uploads at the configured `MAX_UPLOAD_SIZE`. For example, 10 concurrent 10 MB uploads require approximately 100 MB of temporary disk space.
+- **`MAX_UPLOAD_SIZE`** is set appropriately for your use case -- lower it if your files are typically smaller.
+
+:::
+
 ## Google Cloud Storage Configuration
 
 | Variable                         | Description                               | Default |
@@ -91,17 +102,6 @@ Resource attributes emitted by the service:
 | `service.version`             | `version` field in `package.json`                        |
 | `deployment.environment.name` | `DEPLOYMENT_ENVIRONMENT` env var (default `development`) |
 
-:::caution Disk space considerations for file uploads
-
-Uploaded files are temporarily written to the OS temp directory before being forwarded to storage. Temp files are automatically cleaned up after each upload completes or fails.
-
-When planning your deployment, ensure:
-
-- **Temp directory disk space** can accommodate concurrent uploads at the configured `MAX_UPLOAD_SIZE`. For example, 10 concurrent 10 MB uploads require approximately 100 MB of temporary disk space.
-- **`MAX_UPLOAD_SIZE`** is set appropriately for your use case -- lower it if your files are typically smaller.
-
-:::
-
 ## Example Environment File
 
 Example `.env` file for local development:
@@ -123,4 +123,13 @@ LOCAL_DIRECTORY=uploads
 # Buckets
 DEFAULT_BUCKET=documents
 AVAILABLE_BUCKETS=documents,files
+
+# Logging
+# LOG_LEVEL=info        # debug | info | warn | error | fatal
+# LOG_PRETTY=true       # Defaults to on in NODE_ENV=development
+
+# OpenTelemetry (opt-in; SDK starts only when OTEL_EXPORTER_OTLP_ENDPOINT is set)
+# OTEL_EXPORTER_OTLP_ENDPOINT=http://localhost:4317
+# OTEL_SERVICE_NAME=storage-service
+# DEPLOYMENT_ENVIRONMENT=development
 ```

--- a/documentation/versioned_docs/version-4.0.0/deployment-guide/configuration/index.md
+++ b/documentation/versioned_docs/version-4.0.0/deployment-guide/configuration/index.md
@@ -107,29 +107,57 @@ Resource attributes emitted by the service:
 Example `.env` file for local development:
 
 ```env
-# Server
+# Server Configuration
 PROTOCOL=http
 DOMAIN=localhost
 PORT=3333
 # EXTERNAL_PORT=443
 
 # Authentication (Required)
+# The API key used to authenticate upload requests
 API_KEY=your-secure-api-key-here
 
-# Storage
+# Storage Configuration
+# Options: local | gcp | aws
 STORAGE_TYPE=local
 LOCAL_DIRECTORY=uploads
 
-# Buckets
+# Bucket Configuration
+# DEFAULT_BUCKET is used as a fallback when a request does not include a bucket.
+# If unset, requests without a bucket will receive a 400 error.
 DEFAULT_BUCKET=documents
 AVAILABLE_BUCKETS=documents,files
 
-# Logging
-# LOG_LEVEL=info        # debug | info | warn | error | fatal
-# LOG_PRETTY=true       # Defaults to on in NODE_ENV=development
+# Public URL Override
+# When using a CDN or custom domain, override the base URL for document URIs returned to clients.
+# Uploads still go to the configured storage provider. Only the URI in API responses changes.
+# Applies to: aws, gcp (ignored for local storage)
+# PUBLIC_URL=https://cdn.example.com
 
-# OpenTelemetry (opt-in; SDK starts only when OTEL_EXPORTER_OTLP_ENDPOINT is set)
+# Cloud Provider Credentials (if using cloud storage)
+
+# Google Cloud Platform
+# GOOGLE_APPLICATION_CREDENTIALS=/path/to/service-account-file.json
+
+# AWS S3 / S3-Compatible Providers (MinIO, DigitalOcean Spaces, Cloudflare R2, etc.)
+# S3_REGION=ap-southeast-2           # Required for AWS S3, optional with custom endpoint
+# S3_ENDPOINT=http://localhost:9000  # Custom endpoint for S3-compatible providers
+# S3_FORCE_PATH_STYLE=true           # Required for MinIO, Cloudflare R2
+# AWS_ACCESS_KEY_ID=your-access-key-id
+# AWS_SECRET_ACCESS_KEY=your-secret-access-key
+
+# File Upload Configuration
+# MAX_UPLOAD_SIZE=10485760
+# ALLOWED_UPLOAD_TYPES=image/png,image/jpeg,image/webp,application/pdf
+
+# Logging Configuration
+# LOG_LEVEL=info        # debug | info | warn | error | fatal
+# LOG_PRETTY=true       # Pretty-format logs via pino-pretty.
+                        # Defaults to on in NODE_ENV=development; leave unset in production.
+
+# OpenTelemetry Configuration (opt-in)
+# Set OTEL_EXPORTER_OTLP_ENDPOINT to enable tracing; the SDK does nothing when unset.
 # OTEL_EXPORTER_OTLP_ENDPOINT=http://localhost:4317
 # OTEL_SERVICE_NAME=storage-service
-# DEPLOYMENT_ENVIRONMENT=development
+# DEPLOYMENT_ENVIRONMENT=development   # development | production
 ```

--- a/documentation/versioned_docs/version-4.0.0/deployment-guide/configuration/index.md
+++ b/documentation/versioned_docs/version-4.0.0/deployment-guide/configuration/index.md
@@ -50,6 +50,17 @@ For cloud storage provider configuration, see [Storage Providers](../storage-pro
 `MAX_UPLOAD_SIZE` governs the maximum size for both JSON request bodies and multipart file uploads.
 :::
 
+:::caution Disk space considerations for file uploads
+
+Uploaded files are temporarily written to the OS temp directory before being forwarded to storage. Temp files are automatically cleaned up after each upload completes or fails.
+
+When planning your deployment, ensure:
+
+- **Temp directory disk space** can accommodate concurrent uploads at the configured `MAX_UPLOAD_SIZE`. For example, 10 concurrent 10 MB uploads require approximately 100 MB of temporary disk space.
+- **`MAX_UPLOAD_SIZE`** is set appropriately for your use case -- lower it if your files are typically smaller.
+
+:::
+
 ## Google Cloud Storage Configuration
 
 | Variable                         | Description                               | Default |
@@ -91,17 +102,6 @@ Resource attributes emitted by the service:
 | `service.version`             | `version` field in `package.json`                        |
 | `deployment.environment.name` | `DEPLOYMENT_ENVIRONMENT` env var (default `development`) |
 
-:::caution Disk space considerations for file uploads
-
-Uploaded files are temporarily written to the OS temp directory before being forwarded to storage. Temp files are automatically cleaned up after each upload completes or fails.
-
-When planning your deployment, ensure:
-
-- **Temp directory disk space** can accommodate concurrent uploads at the configured `MAX_UPLOAD_SIZE`. For example, 10 concurrent 10 MB uploads require approximately 100 MB of temporary disk space.
-- **`MAX_UPLOAD_SIZE`** is set appropriately for your use case -- lower it if your files are typically smaller.
-
-:::
-
 ## Example Environment File
 
 Example `.env` file for local development:
@@ -123,4 +123,13 @@ LOCAL_DIRECTORY=uploads
 # Buckets
 DEFAULT_BUCKET=documents
 AVAILABLE_BUCKETS=documents,files
+
+# Logging
+# LOG_LEVEL=info        # debug | info | warn | error | fatal
+# LOG_PRETTY=true       # Defaults to on in NODE_ENV=development
+
+# OpenTelemetry (opt-in; SDK starts only when OTEL_EXPORTER_OTLP_ENDPOINT is set)
+# OTEL_EXPORTER_OTLP_ENDPOINT=http://localhost:4317
+# OTEL_SERVICE_NAME=storage-service
+# DEPLOYMENT_ENVIRONMENT=development
 ```


### PR DESCRIPTION
Two post-4.0.0 documentation fixes spotted during review.

## Changes

**`.env.example`** -- added Logging and OpenTelemetry sections at the bottom, with each variable commented-out and accompanied by a brief inline note. Mirrors the env-var contract documented on the Configuration page so a fresh `cp .env.example .env` surfaces every supported variable, not just storage and auth.

**`documentation/docs/deployment-guide/configuration/index.md`** -- two fixes:

- Moved the `:::caution Disk space considerations for file uploads` admonition out of the OpenTelemetry section and placed it immediately after the `:::info MAX_UPLOAD_SIZE governs ...` admonition, where it belongs (the caution is about upload temp files, not telemetry).
- Extended the Example Environment File block with the same Logging and OpenTelemetry stanzas added to `.env.example` so the docs example matches the file consumers actually copy.

**`documentation/versioned_docs/version-4.0.0/deployment-guide/configuration/index.md`** -- same two fixes applied to the 4.0.0 snapshot so the published docs at the tagged commit are correct too.

## Test plan
- [x] `yarn test` green (21 suites, 248 cases).
- [x] `yarn build` clean.
- [x] Source and `version-4.0.0` snapshot copies of the configuration page are now identical.