### PR TITLE
chore(ci): rename docs publish workflow to "Build and Prepare Docs"

### DIFF
--- a/.github/workflows/build_publish_docs.yml
+++ b/.github/workflows/build_publish_docs.yml
@@ -1,4 +1,4 @@
-name: Deploy to GitHub Pages
+name: Build and Prepare Docs
 
 # See: RELEASE_MANAGEMENT_GUIDE.md § Pipelines for trigger behaviour.
 
@@ -15,8 +15,8 @@ permissions:
     contents: write
 
 jobs:
-    deploy:
-        name: Deploy to GitHub Pages
+    build-and-prepare:
+        name: Build and Prepare Docs
         runs-on: ubuntu-latest
         environment: github-pages
 
@@ -49,7 +49,7 @@ jobs:
             # Deploy built documentation to gh-pages branch for GitHub Pages hosting
             # Popular action to deploy to GitHub Pages:
             # Docs: https://github.com/peaceiris/actions-gh-pages#%EF%B8%8F-docusaurus
-            - name: Deploy to GitHub Pages
+            - name: Push to gh-pages
               uses: peaceiris/actions-gh-pages@v4
               with:
                   github_token: ${{ secrets.GITHUB_TOKEN }}

--- a/RELEASE_MANAGEMENT_GUIDE.md
+++ b/RELEASE_MANAGEMENT_GUIDE.md
@@ -223,4 +223,4 @@ workflows in the repository.
 
 ### Build and Prepare Docs
 
-Triggers on push to `main` that touches `documentation/**`. Builds the Docusaurus site and pushes the build output to the `gh-pages` branch. GitHub's own `pages build and deployment` workflow then fires on the `gh-pages` push and publishes the content to the public Pages URL.
+Triggers on push to `main` that touches documentation source or the workflow itself (`documentation/**`, `.github/workflows/build_publish_docs.yml`). Builds the Docusaurus site and pushes the build output to the `gh-pages` branch. GitHub's own `pages build and deployment` workflow then fires on the `gh-pages` push and publishes the content to the public Pages URL.

--- a/RELEASE_MANAGEMENT_GUIDE.md
+++ b/RELEASE_MANAGEMENT_GUIDE.md
@@ -221,6 +221,6 @@ Uses GitHub Actions cache scoped to this workflow (`docker-storage-service`)
 so build layers persist across runs without colliding with other Docker
 workflows in the repository.
 
-### Deploy to GitHub Pages
+### Build and Prepare Docs
 
-Triggers on push to `main`. Builds the Docusaurus site and deploys it.
+Triggers on push to `main` that touches `documentation/**`. Builds the Docusaurus site and pushes the build output to the `gh-pages` branch. GitHub's own `pages build and deployment` workflow then fires on the `gh-pages` push and publishes the content to the public Pages URL.


### PR DESCRIPTION
The workflow's previous name, "Deploy to GitHub Pages", was inaccurate: it does not deploy to Pages. It builds the Docusaurus site and pushes the build output to the `gh-pages` branch. GitHub's own `pages build and deployment` workflow then fires on that push and is the step that actually deploys content to the public Pages URL. The old name overlapped with the GH-managed run and made the Actions tab confusing, with two runs called something-Pages-deploy on every docs change.

This PR renames the workflow display name, the job, and the relevant step in `build_publish_docs.yml`, and updates the corresponding section in `RELEASE_MANAGEMENT_GUIDE.md`. The file name (`build_publish_docs.yml`) and trigger behaviour are unchanged.

## Changes

- `build_publish_docs.yml`:
  - Workflow `name`: "Deploy to GitHub Pages" -> "Build and Prepare Docs"
  - Job id `deploy` -> `build-and-prepare`; job `name` matches the workflow name
  - Step that runs `peaceiris/actions-gh-pages@v4`: "Deploy to GitHub Pages" -> "Push to gh-pages" (the step actually pushes to `gh-pages`; GH then deploys)
- `RELEASE_MANAGEMENT_GUIDE.md` Pipelines section: header renamed; description rewritten to call out the two-stage flow (this workflow pushes to `gh-pages`, GitHub's own workflow deploys from there).

## Test plan
- [x] YAML hand-checked (`name:` and step names updated cleanly).
- [ ] CI will validate on the next merge to `main` that the renamed workflow still fires and pushes to `gh-pages` as before.